### PR TITLE
untie playbooks

### DIFF
--- a/automation/run.sh
+++ b/automation/run.sh
@@ -96,6 +96,7 @@ main() {
 
     local cluster_type="${CLUSTER_TYPE:-openshift}"
     local mode="${MODE:-release}"
+    local provider="${PROVIDER:-lago}"
     local run_path="$(get_run_path "$cluster_type")"
     local args=("prefix=$run_path")
 
@@ -118,14 +119,14 @@ main() {
         exit 1
     fi
 
-    args+=("mode=$mode")
+    args+=("mode=$mode" "provider=$provider")
 
     ansible-playbook \
         -u root \
         -i inventory \
         -v \
         -e "${args[*]}" \
-        deploy-with-lago.yml
+        control.yml
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then

--- a/control.yml
+++ b/control.yml
@@ -1,0 +1,3 @@
+- include: "{{ playbook_dir }}/deploy-with-{{ provider | default('lago') }}.yml"
+- include: "{{ playbook_dir }}/deploy-{{ cluster_type | default('openshift') }}.yml"
+- include: "{{ playbook_dir }}/install-kubevirt-{{ mode | default('release') }}.yml"

--- a/deploy-openshift.yml
+++ b/deploy-openshift.yml
@@ -33,5 +33,3 @@
         oc login -u system:admin
         oc get user "$user_name" || oc create user "$user_name"
         oc adm policy add-cluster-role-to-user cluster-admin "$user_name"
-
-- include: "{{ playbook_dir }}/install-kubevirt-{{ mode }}.yml"

--- a/deploy-with-lago.yml
+++ b/deploy-with-lago.yml
@@ -70,5 +70,3 @@
         openshift_node_labels:
           region: infra
           zone: default
-
-- include: "deploy-{{ cluster_type | default('openshift') }}.yml"


### PR DESCRIPTION
Adding control.yml which includes all the steps required
for installing and testing kubevirt.

With this change, each playbook can be used on its own.

Signed-off-by: gbenhaim <galbh2@gmail.com>