### PR TITLE
Deploy With Kcli

### DIFF
--- a/deploy-with-kcli.yml
+++ b/deploy-with-kcli.yml
@@ -1,0 +1,37 @@
+---
+- name: Deploy Openshift
+  hosts: localhost
+  connection: local
+  vars:
+    ansible_python_interpreter: "/usr/bin/env python"
+  tasks:
+    - name: Deploy Openshift Kcli Product
+      register: openshift_installed
+      kvirt_product:
+        name: kubevirt
+        state: present
+        product: asb
+    - name: Wait for Ip of Master to be available
+      wait_for:
+       timeout: 150
+      when: openshift_installed.changed
+    - name: Refresh Inventory
+      meta: refresh_inventory
+      when: openshift_installed.changed
+
+- name: Deploy kubevirt
+  hosts: asb
+  tasks:
+   - name: Wait For Openshift To Be Up
+     wait_for:
+      port: 8443
+      timeout: 300
+   - name: Login Openshift
+     command: "oc login localhost:8443 --insecure-skip-tls-verify=true --username=developer --password=developer"
+   - name: Render Kubevirt Service Instance Yaml
+     template:
+       src: templates/kubevirt-apb.yml.j2
+       dest: /tmp/kubevirt.yml
+   - name: Deploy Kubevirt Service Instance
+     command: "oc create -f /tmp/kubevirt.yml"
+     ignore_errors: true

--- a/klist.py
+++ b/klist.py
@@ -1,0 +1,106 @@
+#!/usr/bin/python
+
+'''
+ansible dynamic inventory script for use with kcli and libvirt
+'''
+
+from kvirt.config import Kconfig
+from kvirt.kvm import Kvirt
+try:
+    from kvirt.vbox import Kbox
+except:
+    pass
+import json
+import os
+import argparse
+
+
+def empty():
+    return {'_meta': {'hostvars': {}}}
+
+
+class KcliInventory(object):
+
+    def __init__(self):
+        self.inventory = {}
+        self.read_cli_args()
+        config = Kconfig(quiet=True)
+        self.host = config.host
+        self.port = config.port
+        self.user = config.user
+        protocol = config.protocol
+        self.tunnel = config.tunnel
+        self.type = config.type
+        if self.type == 'vbox':
+            self.k = Kbox()
+        else:
+            self.k = Kvirt(host=self.host, port=self.port, user=self.user, protocol=protocol)
+        if self.k.conn is None:
+            os._exit(1)
+
+        # Called with `--list`.
+        if self.args.list:
+            self.inventory = self.get()
+        # Called with `--host [hostname]`.
+        elif self.args.host:
+            # Not implemented, since we return _meta info `--list`.
+            self.inventory = empty()
+        # If no groups or vars are present, return an empty inventory.
+        else:
+            self.inventory = empty()
+        print json.dumps(self.inventory)
+
+    # Read the command line args passed to the script.
+    def read_cli_args(self):
+        parser = argparse.ArgumentParser()
+        parser.add_argument('--list', action='store_true')
+        parser.add_argument('--host', action='store')
+        self.args = parser.parse_args()
+
+    def get(self):
+        ubuntus = ['utopic', 'vivid', 'wily', 'xenial', 'yakkety']
+        k = self.k
+        tunnel = self.tunnel
+        metadata = {'_meta': {'hostvars': {}}}
+        hostvalues = metadata['_meta']['hostvars']
+        for vm in k.list():
+            name = vm[0]
+            status = vm[1]
+            ip = vm[2]
+            template = vm[3]
+            description = vm[4]
+            profile = vm[5]
+            if description == '':
+                description = 'kvirt'
+            if description not in metadata:
+                metadata[description] = {"hosts": [name], "vars": {"plan": description, "profile": profile}}
+            else:
+                metadata[description]["hosts"].append(name)
+            hostvalues[name] = {'status': status}
+            if tunnel and self.type == 'kvm':
+                hostvalues[name]['ansible_ssh_common_args'] = "-o ProxyCommand='ssh -p %s -W %%h:%%p %s@%s'" % (self.port, self.user, self.host)
+            if ip != '':
+                if self.type == 'vbox':
+                    hostvalues[name]['ansible_host'] = '127.0.0.1'
+                    hostvalues[name]['ansible_port'] = ip
+                else:
+                    hostvalues[name]['ansible_host'] = ip
+            if template != '':
+                if 'centos' in template.lower():
+                    hostvalues[name]['ansible_user'] = 'centos'
+                elif 'cirros' in template.lower():
+                    hostvalues[name]['ansible_user'] = 'cirros'
+                elif [x for x in ubuntus if x in template.lower()]:
+                    hostvalues[name]['ansible_user'] = 'ubuntu'
+                elif 'fedora' in template.lower():
+                    hostvalues[name]['ansible_user'] = 'fedora'
+                elif 'rhel' in template.lower():
+                    hostvalues[name]['ansible_user'] = 'cloud-user'
+                elif 'debian' in template.lower():
+                    hostvalues[name]['ansible_user'] = 'debian'
+                elif 'arch' in template.lower():
+                    hostvalues[name]['ansible_user'] = 'arch'
+        return metadata
+
+# Get the inventory.
+KcliInventory()

--- a/library/kvirt_plan.py
+++ b/library/kvirt_plan.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+
+from ansible.module_utils.basic import AnsibleModule
+from kvirt.config import Kconfig
+
+
+DOCUMENTATION = '''
+module: kvirt_plan
+short_description: Deploy a plan using kcli
+description:
+    - Longer description of the module
+    - You might include instructions
+version_added: "0.1"
+author: "Karim Boumedhel, @karmab"
+notes:
+    - Details at https://github.com/karmab/kcli
+requirements:
+    - kcli python package you can grab from pypi'''
+
+EXAMPLES = '''
+- name: Deploy origin
+  kvirt_plan:
+    name: my_plan
+    product: origin
+
+- name: Delete that plan
+  kvirt_plan:
+    name: my_plan
+    state: absent
+
+'''
+
+
+def main():
+    argument_spec = {
+        "state": {
+            "default": "present",
+            "choices": ['present', 'absent'],
+            "type": 'str'
+        },
+        "name": {"required": True, "type": "str"},
+        "src": {"required": True, "type": "str"},
+        "parameters": {"required": False, "type": "dict"},
+    }
+    module = AnsibleModule(argument_spec=argument_spec)
+    config = Kconfig(quiet=True)
+    name = module.params['name']
+    src = module.params['src']
+    plans = [p[0] for p in config.list_plans()]
+    exists = True if name in plans else False
+    state = module.params['state']
+    if state == 'present':
+        if exists:
+            changed = False
+            skipped = True
+            meta = {'result': 'skipped'}
+        else:
+            overrides = module.params['parameters'] if module.params['parameters'] is not None else {}
+            meta = config.plan(name, inputfile=src, overrides=overrides)
+            changed = True
+            skipped = False
+    else:
+        if exists:
+            meta = config.plan(name, delete=True)
+            changed = True
+            skipped = False
+        else:
+            changed = False
+            skipped = True
+            meta = {'result': 'skipped'}
+    module.exit_json(changed=changed, skipped=skipped, meta=meta)
+
+if __name__ == '__main__':
+    main()

--- a/library/kvirt_product.py
+++ b/library/kvirt_product.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+
+from ansible.module_utils.basic import AnsibleModule
+from kvirt.config import Kconfig
+
+
+DOCUMENTATION = '''
+module: kvirt_product
+short_description: Deploy a product using kcli
+description:
+    - Longer description of the module
+    - You might include instructions
+version_added: "0.1"
+author: "Karim Boumedhel, @karmab"
+notes:
+    - Details at https://github.com/karmab/kcli
+requirements:
+    - kcli python package you can grab from pypi'''
+
+EXAMPLES = '''
+- name: Deploy origin
+  kvirt_product:
+    name: my_origin
+    product: origin
+
+- name: Delete that product
+  kvirt_product:
+    name: my_origin
+    state: absent
+
+- name: Deploy fission with additional parameters
+  kvirt_product:
+    name: fission
+    product: fission
+    parameters:
+     fission_type: all
+     docker_disk_size: 10
+'''
+
+
+def main():
+    argument_spec = {
+        "state": {
+            "default": "present",
+            "choices": ['present', 'absent'],
+            "type": 'str'
+        },
+        "name": {"required": True, "type": "str"},
+        "product": {"required": True, "type": "str"},
+        "repo": {"required": False, "type": "str"},
+        "parameters": {"required": False, "type": "dict"},
+    }
+    module = AnsibleModule(argument_spec=argument_spec)
+    config = Kconfig(quiet=True)
+    name = module.params['name']
+    product = module.params['product']
+    repo = module.params['repo']
+    plans = [p[0] for p in config.list_plans()]
+    exists = True if name in plans else False
+    state = module.params['state']
+    if state == 'present':
+        if exists:
+            changed = False
+            skipped = True
+            meta = {'result': 'skipped'}
+        else:
+            overrides = module.params['parameters'] if module.params['parameters'] is not None else {}
+            meta = config.create_product(product, repo=repo, plan=name, overrides=overrides)
+            changed = True
+            skipped = False
+    else:
+        if exists:
+            meta = config.plan(name, delete=True)
+            changed = True
+            skipped = False
+        else:
+            changed = False
+            skipped = True
+            meta = {'result': 'skipped'}
+    module.exit_json(changed=changed, skipped=skipped, meta=meta)
+
+if __name__ == '__main__':
+    main()

--- a/templates/broker-config.yml.j2
+++ b/templates/broker-config.yml.j2
@@ -1,0 +1,63 @@
+apiVersion: v1
+data:
+  broker-config: |
+    registry:
+      - type: "dockerhub"
+        name: "dh"
+        url: "https://registry.hub.docker.com"
+        org: "ansibleplaybookbundle"
+        tag: "latest"
+        white_list:
+          - ".*-apb$"
+      - type: local_openshift
+        name: localregistry
+        namespaces: ['openshift']
+        white_list:
+          - ".*-apb$"
+      - type: "dockerhub"
+        name: "karmab"
+        url: "https://registry.hub.docker.com"
+        org: "karmab"
+        tag: "latest"
+        white_list:
+          - ".*-apb$"
+    dao:
+      etcd_host: asb-etcd.ansible-service-broker.svc
+      etcd_port: 2379
+      etcd_ca_file: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+      etcd_client_cert: /var/run/asb-etcd-auth/client.crt
+      etcd_client_key: /var/run/asb-etcd-auth/client.key
+    log:
+      logfile: /var/log/ansible-service-broker/asb.log
+      stdout: true
+      level: debug
+      color: true
+    openshift:
+      host: ""
+      ca_file: ""
+      bearer_token_file: ""
+      image_pull_policy: "IfNotPresent"
+      sandbox_role: "edit"
+      namespace: ansible-service-broker
+      keep_namespace: false
+      keep_namespace_on_error: true
+    broker:
+      dev_broker: true
+      bootstrap_on_startup: true
+      refresh_interval: "600s"
+      launch_apb_on_bind: false
+      output_request: true
+      recovery: true
+      ssl_cert_key: /etc/tls/private/tls.key
+      ssl_cert: /etc/tls/private/tls.crt
+      auto_escalate: false
+      auth:
+        - type: basic
+          enabled: false
+kind: ConfigMap
+metadata:
+  creationTimestamp: 2018-02-01T18:19:47Z
+  labels:
+    app: ansible-service-broker
+  name: broker-config
+  namespace: ansible-service-broker

--- a/templates/kubevirt-apb.yml.j2
+++ b/templates/kubevirt-apb.yml.j2
@@ -1,0 +1,11 @@
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ServiceInstance
+metadata:
+  name: kubevirt
+  namespace: kube-system
+spec:
+  clusterServiceClassExternalName: dh-kubevirt-apb
+  clusterServicePlanExternalName: default
+  parameters:
+   admin_user: {{ admin_user | default('developer') }}
+   admin_password: {{ admin_password | default('developer') }}


### PR DESCRIPTION
An example of how to:
- use kcli for provisioning of openshift with asb
- how to deploy kubevirt using apb

the corresponding apb code is: 
- at https://github.com/karmab/kubevirt-apb
- published at docker.io/karmab/kubevirt-apb

to make use of the apb, the broker-config config-map of the ansible-service-broker namespace needs to be edited so it contains the following:

```
      - type: "dockerhub"
        name: "karmab"
        url: "https://registry.hub.docker.com"
        org: "karmab"
        tag: "latest"
        white_list:
          - ".*-apb$"
```



