### PR TITLE
Run Kubevirt's functional tests

### DIFF
--- a/automation/check-patch.mounts
+++ b/automation/check-patch.mounts
@@ -2,3 +2,4 @@
 /var/lib/libvirt/boot
 /var/lib/lago
 /dev/shm
+/var/run/docker.sock:/var/run/docker.sock

--- a/automation/check-patch.packages
+++ b/automation/check-patch.packages
@@ -1,3 +1,4 @@
 lago
 ansible-2.3.1.0-3.el7
 origin-clients
+docker

--- a/automation/run.sh
+++ b/automation/run.sh
@@ -17,7 +17,7 @@ get_run_path() {
 
 collect_logs() {
     local run_path="$1"
-    local artifacts_dir="exported-artifacts"
+    local artifacts_dir="$2"
     local vms_logs="${artifacts_dir}/vms_logs"
 
     mkdir -p "$vms_logs"
@@ -38,7 +38,9 @@ collect_logs() {
 cleanup() {
     set +e
     local run_path="$1"
-    collect_logs "$run_path"
+    local artifacts_dir="$2"
+
+    collect_logs "$run_path" "$artifacts_dir"
     lago --workdir "$run_path" destroy --yes \
     || force_cleanup
 }
@@ -94,14 +96,16 @@ main() {
     #   dev - install kubevirt with the dev manifests, and
     #   build kubevirt's containers on the vms
 
+    local artifacts_dir="exported-artifacts"
     local cluster_type="${CLUSTER_TYPE:-openshift}"
     local mode="${MODE:-release}"
     local provider="${PROVIDER:-lago}"
     local run_path="$(get_run_path "$cluster_type")"
     local args=("prefix=$run_path")
 
-    trap "cleanup $run_path" EXIT
+    trap "cleanup $run_path $artifacts_dir" EXIT
 
+    mkdir -p "$artifacts_dir"
     set_params
     install_requirements
 
@@ -127,6 +131,15 @@ main() {
         -v \
         -e "${args[*]}" \
         control.yml
+
+    echo "Running functional tests"
+    http_proxy="" timeout \
+        --kill-after 5m \
+        120m \
+        ./run-kubevirt-functional-tests.sh \
+            --kubeconfig ".kube/config" \
+            --commit "master" \
+            --output "$artifacts_dir"
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then

--- a/install-kubevirt-release.yml
+++ b/install-kubevirt-release.yml
@@ -14,6 +14,7 @@
     kubevirt_repo_path: "{{ playbook_dir }}/kubevirt"
     kubevirt_mf_template: "{{ kubevirt_repo_path }}/manifests/release/kubevirt.yaml.in"
     kubevirt_mf: "{{ kubevirt_repo_path }}/manifests/release/kubevirt.yaml"
+    kubevirt_testing_mf_dir: "{{ kubevirt_repo_path }}/manifests/testing"
     docker_prefix: kubevirt
     docker_tag: latest
     lib_oc_path: "{{ playbook_dir }}/openshift-ansible/roles/lib_openshift"
@@ -27,6 +28,19 @@
       template:
         src: "{{ kubevirt_mf_template }}"
         dest: "{{ kubevirt_mf }}"
+
+    - name: Generate testing resources from template
+      template:
+        src: "{{ item }}"
+        dest: "{{ item | splitext | first }}"
+      register: testing_mf
+      with_fileglob:
+        - "{{ kubevirt_testing_mf_dir }}/*.in"
+
+    # If the templates already been generated, we need
+    # a different key for extracting their path.
+    - set_fact:
+        key: "{{ 'dest' if testing_mf.changed else 'path' }}"
 
     # oc requires that the master will be resolvable
     - name: Add master's fqdn to /etc/hosts
@@ -46,12 +60,13 @@
           --insecure-skip-tls-verify=true \
           "https://${master_fqdn}:8443"
 
-    - name: Install Kubevirt
-      debug:
-        msg: "Installing Kubevirt"
+    - debug:
+        msg: Installing Kubevirt and Kubevirt's testing resources
 
   roles:
-    - "{{ playbook_dir }}/openshift/roles/kubevirt"
+    - role: "{{ playbook_dir }}/openshift/roles/kubevirt"
+    - role: "{{ playbook_dir }}/openshift/roles/kubevirt_testing"
+      kubevirt_mf: "{{ testing_mf.results | map(attribute=key) | list }}"
 
   post_tasks:
     - name: List Kubevirt's reousrces
@@ -59,3 +74,5 @@
         oc project kube-system
         oc get pods
         oc get ds
+        oc get persistentvolumes
+        oc get persistentvolumeclaims

--- a/openshift/roles/kubevirt/filter_plugins/kubevirt_filters.py
+++ b/openshift/roles/kubevirt/filter_plugins/kubevirt_filters.py
@@ -14,25 +14,29 @@ def mf_to_dict(mf):
     kind -> list of dicts
 
     Args:
-        mf (str): Path to a yaml file
+        mf (str or list): Paths to yaml files
 
     Returns:
         (dict)
     """
     d = defaultdict(list)
 
-    with open(mf) as f:
-        docs = yaml.safe_load_all(f)
+    if not isinstance(mf, list):
+        mf = [mf]
 
-        for doc in docs:
-            kind = doc['kind']
-            name = doc['metadata']['name']
-            d[kind].append(
-                {
-                    'name': name,
-                    'manifest': doc
-                }
-            )
+    for m in mf:
+        with open(m) as f:
+            docs = yaml.safe_load_all(f)
+
+            for doc in docs:
+                kind = doc['kind']
+                name = doc['metadata']['name']
+                d[kind].append(
+                    {
+                        'name': name,
+                        'manifest': doc
+                    }
+                )
 
     return dict(d)
 

--- a/openshift/roles/kubevirt/tasks/oc_obj_task.yml
+++ b/openshift/roles/kubevirt/tasks/oc_obj_task.yml
@@ -9,3 +9,4 @@
       data: "{{ item.manifest }}"
       path: "/tmp/{{ kind }}"
   with_items: "{{ normalized_mf[kind] }}"
+  when: kind in normalized_mf

--- a/openshift/roles/kubevirt_testing/defaults
+++ b/openshift/roles/kubevirt_testing/defaults
@@ -1,0 +1,1 @@
+../kubevirt/defaults/

--- a/openshift/roles/kubevirt_testing/filter_plugins
+++ b/openshift/roles/kubevirt_testing/filter_plugins
@@ -1,0 +1,1 @@
+../kubevirt/filter_plugins/

--- a/openshift/roles/kubevirt_testing/meta
+++ b/openshift/roles/kubevirt_testing/meta
@@ -1,0 +1,1 @@
+../kubevirt/meta/

--- a/openshift/roles/kubevirt_testing/tasks/main.yml
+++ b/openshift/roles/kubevirt_testing/tasks/main.yml
@@ -1,0 +1,32 @@
+- name: Normalize kubevirt.yaml
+  set_fact:
+    normalized_mf: "{{ kubevirt_mf | mf_to_dict }}"
+
+- name: RBAC
+  include: "oc_obj_task.yml"
+  loop_control:
+    loop_var: kind
+  with_items:
+    - ServiceAccount
+    - ClusterRoleBinding
+
+- name: Create scc
+  oc_adm_policy_user:
+    resource_kind: scc
+    resource_name: privileged
+    user: "system:serviceaccount:{{ project }}:{{ item }}"
+    kubeconfig: "{{ kconfig }}"
+    state: "{{ state }}"
+  with_items:
+    - kubevirt-testing
+
+- name: Create testing resources
+  include: "oc_obj_task.yml"
+  loop_control:
+    loop_var: kind
+  with_items:
+    - PersistentVolume
+    - PersistentVolumeClaim
+    - Secret
+    - Deployment
+    - Service

--- a/openshift/roles/kubevirt_testing/tasks/oc_obj_task.yml
+++ b/openshift/roles/kubevirt_testing/tasks/oc_obj_task.yml
@@ -1,0 +1,1 @@
+../../kubevirt/tasks/oc_obj_task.yml

--- a/openshift/roles/prerequisites/tasks/main.yml
+++ b/openshift/roles/prerequisites/tasks/main.yml
@@ -5,7 +5,7 @@
 - name: set SELinux to permissive mode under configuration file
   selinux:
     policy: targeted
-    state: enforcing
+    state: permissive
 
 - name: stop and disable firewalld
   register: result

--- a/run-kubevirt-functional-tests.sh
+++ b/run-kubevirt-functional-tests.sh
@@ -1,0 +1,140 @@
+#!/bin/bash -ex
+
+usage() {
+        echo "
+Usage:
+
+$0 [options]
+
+This script will run Kubvirt's functional tests on an existing cluster.
+The following are prerequisites for this script:
+
+* You must have an up and running cluster.
+* Kubevirt and it's testing resources must be deployed on the cluster.
+  This can be achieved with 'kubevirt' and 'kubevirt_testing' roles.
+* Docker must run on the local machine.
+* Make should be installed on the local machine.
+
+Optional arguments:
+    -h,--help PATH
+        Print this message and quite.
+
+    -k,--kubeconfig PATH_TO_KUBECONFIG
+        Kubeconfig which points to the cluster.
+        The default path is '$HOME/.kube/config'.
+
+    -c,--commit COMMIT
+        Which commit to checkout before compiling the code.
+
+    -o,--output OUTPUT_PATH
+        A path for a directory for saving the test's log.
+        If not specified the logs will not be saved.
+"
+}
+
+verify_dependencies () {
+    systemctl is-active docker > /dev/null || {
+        echo "Please enable docker and re-run $0"
+        exit 1
+    }
+
+    hash make > /dev/null || {
+        echo "Please install make and re-run $0"
+        exit 1
+    }
+
+    echo "Verified dependencies, we are ready to go..."
+}
+
+main() {
+    local kubeconfig="$(realpath ${KUBECONFIG:-$HOME/.kube/config})"
+    local commit="${COMMIT:-master}"
+    local output_path="$OUTPUT_PATH"
+    local kubevirt_repo_url="https://github.com/kubevirt/kubevirt.git"
+    local kubevirt_repo_path="/tmp/kubevirt"
+    local test_bin_path="${kubevirt_repo_path}/_out/tests/tests.test"
+
+    [[ -f "$kubeconfig" ]] || {
+        echo "kubeconfig $kubeconfig doesn't exist"
+        exit 1
+    }
+
+    [[ -d "$kubevirt_repo_path" ]] || {
+        echo "Cloning kubevirt's repo"
+        git clone "$kubevirt_repo_url" "$kubevirt_repo_path"
+    }
+
+    pushd "$kubevirt_repo_path"
+    echo "Checking out $commit"
+    git checkout "$commit"
+
+    echo "Compiling tests"
+    make || {
+        echo "Failed to compile tests. Cleaning cache and retrying..."
+        make distclean
+        make
+    }
+    popd
+
+    echo "Running functional tests"
+    if [[ -d "$output_path" ]]; then
+        output_path="$(realpath "${output_path}/test.log")"
+        echo "Logs will be written to $output_path"
+        "$test_bin_path" -kubeconfig "$kubeconfig" | tee "$output_path"
+    else
+        "$test_bin_path" -kubeconfig "$kubeconfig"
+    fi
+
+    if [[ ${PIPESTATUS[0]} -ne 0 ]]; then
+        echo "Some tests failed..."
+    else
+        echo "All tests passed !"
+    fi
+
+    exit "${PIPESTATUS[0]}"
+}
+
+options=$( \
+    getopt \
+        -o k:c:o:h \
+        --long kubeconfig:,commit:,output:,help \
+        -n 'run-kubevirt-functional-tests.sh' \
+        -- "$@" \
+)
+
+if [[ "$?" != "0" ]]; then
+    exit 1
+fi
+eval set -- "$options"
+
+while true; do
+    case $1 in
+        -k|--kubeconfig)
+            readonly KUBECONFIG="$2"
+            shift 2
+            ;;
+        -c|--commit)
+            readonly COMMIT="$2"
+            shift 2
+            ;;
+        -o|--output)
+            readonly OUTPUT_PATH="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *)
+            echo "Unkown option $1"
+            usage
+            exit 1
+    esac
+done
+
+verify_dependencies
+main


### PR DESCRIPTION
openshift: Adding kubevirt_testing role
- This role will deploy Kubevirt's test resources (iscsi etc...)
- Modified "kubevirt_filters.py" to accept multiple manifests.
- Modified "oc_obj_task.yml" if a specific "kind" is not in the dict.
- Modified install-kubevirt-release.yml to deploy the testing resources.

Run Kubvirt's functional tests
- Adding "run-kubevirt-functional-tests.sh" which
  clone, compile and run Kubvirt's functional tests.
- Disable selinux on all VMs.
- Update the automation file so docker can be run inside
  the mock env.
- Update run.sh to trigger "run-kubevirt-functional-tests.sh",
  and to save the tests logs in the exported-artifacts dir.