### PR TITLE
Use Ansible 2.4.2 - part 1

### DIFF
--- a/automation/check-patch.packages
+++ b/automation/check-patch.packages
@@ -1,3 +1,3 @@
 lago
-ansible-2.3.1.0-3.el7
+ansible-2.4.2.0-2.el7
 origin-clients

--- a/automation/run.sh
+++ b/automation/run.sh
@@ -99,6 +99,7 @@ main() {
     local provider="${PROVIDER:-lago}"
     local run_path="$(get_run_path "$cluster_type")"
     local args=("prefix=$run_path")
+    local inventory_file="$(realpath inventory)"
 
     trap "cleanup $run_path" EXIT
 
@@ -119,11 +120,15 @@ main() {
         exit 1
     fi
 
-    args+=("mode=$mode" "provider=$provider")
+    args+=(
+        "mode=$mode"
+        "provider=$provider"
+        "inventory_file=$inventory_file"
+    )
 
     ansible-playbook \
         -u root \
-        -i inventory \
+        -i "$inventory_file" \
         -v \
         -e "${args[*]}" \
         control.yml

--- a/deploy-openshift.yml
+++ b/deploy-openshift.yml
@@ -8,7 +8,7 @@
       yum:
         name: python-yaml
     - name: Include openshift_facts module
-      include_role:
+      import_role:
         name: "{{ openshift_ansible_dir }}/roles/openshift_facts"
     - name: Load openshift facts
       openshift_facts:

--- a/deploy-with-lago.yml
+++ b/deploy-with-lago.yml
@@ -1,3 +1,12 @@
+# Desription: Create a virtual environment using Lago.
+# The specification of the environment can be found in LagoInitFile.yaml
+#
+# PARAMETERS:
+# inventory_file: Path to the inventory file,
+# Lago will populate it with the vms details.
+#
+# prefix: Where to create the lago environment
+
 - hosts: localhost
   connection: local
   gather_facts: False


### PR DESCRIPTION
lago: Explicitly specify "inventory_file" variable
In Ansible 2.4.2 the "inventory_file" variable was dropped.
We need this variable in order to let Lago dynamically update the
inventory file with the details of the VMs, thus specify it explicitly.

Use Ansible 2.4.2