### PR TITLE
Unite name of parameter for kubeconfig in repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ playbook to install KubeVirt from given manifest.
 | ---------------- | ------------- | -------------------------------------- |
 | kubevirt\_mf     | string | Path to KubeVirt manifest, you can get one from [releases](https://github.com/kubevirt/kubevirt/releases) or build it from sources |
 | openshift\_ansible\_dir | string | Path to [OpenShift Ansible project][openshift-ansible-project] |
-| kubeconfig | string | Path to kubeconfig |
+| kubeconfig | string | Path to the [`~/.kube/config`](https://docs.openshift.com/container-platform/3.7/cli_reference/manage_cli_profiles.html#switching-between-cli-profiles) file containing authentication information for the desired cluster |
 
 ```bash
 $ # Get KubeVirt manifest

--- a/README.md
+++ b/README.md
@@ -146,14 +146,14 @@ playbook to install KubeVirt from given manifest.
 | ---------------- | ------------- | -------------------------------------- |
 | kubevirt\_mf     | string | Path to KubeVirt manifest, you can get one from [releases](https://github.com/kubevirt/kubevirt/releases) or build it from sources |
 | openshift\_ansible\_dir | string | Path to [OpenShift Ansible project][openshift-ansible-project] |
-| kconfig | string | Path to kubeconfig |
+| kubeconfig | string | Path to kubeconfig |
 
 ```bash
 $ # Get KubeVirt manifest
 $ wget https://github.com/kubevirt/kubevirt/releases/download/v0.2.0/kubevirt.yaml
 $ ansible-playbook -i localhost, --connection=local \
         -e "openshift_ansible_dir=openshift-ansible/ \
-        kconfig=$HOME/.kube/config \
+        kubeconfig=$HOME/.kube/config \
         kubevirt_mf=kubevirt.yaml" \
         install-kubevirt-on-openshift.yml
 ```

--- a/install-kubevirt-on-openshift.yml
+++ b/install-kubevirt-on-openshift.yml
@@ -1,7 +1,7 @@
 ---
 # PARAMETERS
 # - kubevirt_mf
-# - kconfig
+# - kubeconfig
 # - openshift_ansible_dir
 - hosts: localhost
   connection: local
@@ -13,8 +13,8 @@
         msg: "Missing 'openshift_ansible_dir' parameter"
       when: openshift_ansible_dir is not defined
     - fail:
-        msg: "Missing 'kconfig' parameter"
-      when: kconfig is not defined
+        msg: "Missing 'kubeconfig' parameter"
+      when: kubeconfig is not defined
     - fail:
         msg: "Missing 'kubevirt_mf' parameter"
       when: kubevirt_mf is not defined

--- a/openshift/roles/kubevirt/defaults/main.yml
+++ b/openshift/roles/kubevirt/defaults/main.yml
@@ -1,3 +1,3 @@
 project: "kube-system"
 state: present
-kconfig: ".kube/config"
+kubeconfig: ".kube/config"

--- a/openshift/roles/kubevirt/tasks/main.yml
+++ b/openshift/roles/kubevirt/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: Get Openshift version
   oc_version:
-    kubeconfig: "{{ kconfig }}"
+    kubeconfig: "{{ kubeconfig }}"
   register: oc_version
 
 - name: Normalize kubevirt.yaml
@@ -10,7 +10,7 @@
 - name: Create project
   oc_project:
     name: "{{ project }}"
-    kubeconfig: "{{ kconfig }}"
+    kubeconfig: "{{ kubeconfig }}"
     state: "{{ state }}"
 
 - name: RBAC
@@ -27,7 +27,7 @@
     resource_kind: scc
     resource_name: privileged
     user: "system:serviceaccount:{{ project }}:{{ item }}"
-    kubeconfig: "{{ kconfig }}"
+    kubeconfig: "{{ kubeconfig }}"
     state: "{{ state }}"
   with_items:
     - kubevirt-privileged

--- a/openshift/roles/kubevirt/tasks/oc_obj_task.yml
+++ b/openshift/roles/kubevirt/tasks/oc_obj_task.yml
@@ -1,7 +1,7 @@
 - name: "Running oc_obj wrapper"
   oc_obj:
     name: "{{ item.name }}"
-    kubeconfig: "{{ kconfig }}"
+    kubeconfig: "{{ kubeconfig }}"
     namespace: "{{ project }}"
     kind: "{{ kind }}"
     state: "{{ state }}"


### PR DESCRIPTION
We have roles for Kubernetes which use 'kubeconfig' parameter.
And next to it we have roles for OpenShift and here we use 'kconfig' as a
name for kubeconfig parameter.

This change unite name of this parameter to be 'kubeconfig' for all
roles in this repository.