### PR TITLE
Adding new requirement for openshift_facts

### DIFF
--- a/deploy-openshift.yml
+++ b/deploy-openshift.yml
@@ -2,9 +2,12 @@
 - hosts: all
   remote_user: root
   pre_tasks:
-    - name: Install python-yaml (required by openshift_facts)
+    - name: Install openshift_facts requirements
       yum:
-        name: python-yaml
+        name: "{{ item }}"
+      with_items:
+        - python-yaml
+        - python-ipaddress
     - name: Include openshift_facts module
       import_role:
         name: "{{ openshift_ansible_dir }}/roles/openshift_facts"


### PR DESCRIPTION
They backported change [1] into release-3.7 branch,
which breaks our deploy-openshift.yml playbook.

It is necessary to install python-ipaddress package to satisfy that
requirement.

[1] https://github.com/openshift/openshift-ansible/pull/7137