### PR TITLE
Use std-ci mirrors

### DIFF
--- a/automation/check-patch.openshift_3-7.yumrepos
+++ b/automation/check-patch.openshift_3-7.yumrepos
@@ -1,0 +1,1 @@
+check-patch.yumrepos

--- a/automation/check-patch.openshift_3-9.yumrepos
+++ b/automation/check-patch.openshift_3-9.yumrepos
@@ -1,0 +1,1 @@
+check-patch.yumrepos

--- a/automation/check-patch.sh
+++ b/automation/check-patch.sh
@@ -135,6 +135,12 @@ main() {
         exit 1
     fi
 
+    [[ -f "$STD_CI_YUMREPOS" ]] && {
+        echo "Using std-ci yum repos:"
+	    cat "$STD_CI_YUMREPOS"
+        args+=("std_ci_yum_repos=$(realpath "$STD_CI_YUMREPOS")")
+    }
+
     args+=(
         "mode=$mode"
         "provider=$provider"

--- a/automation/check-patch.yumrepos
+++ b/automation/check-patch.yumrepos
@@ -1,0 +1,23 @@
+[centos-base-el7]
+name = CentOS7 Base
+baseurl = http://mirror.centos.org/centos/7/os/x86_64/
+enabled = 1
+cost = 100
+
+[centos-updates-el7]
+name = CentOS7 Updates
+baseurl = http://mirror.centos.org/centos/7/updates/x86_64/
+enabled = 1
+cost = 100
+
+[centos-extras-el7]
+name = CentOS7 Extras
+baseurl = http://mirror.centos.org/centos/7/extras/x86_64/
+enabled = 1
+cost = 100
+
+[epel-el7]
+name = Extra Packages for Enterprise Linux 7 - x86_64
+baseurl = http://download.fedoraproject.org/pub/epel/7/x86_64
+enabled = 1
+cost = 100

--- a/control.yml
+++ b/control.yml
@@ -1,3 +1,5 @@
 - import_playbook: "{{ playbook_dir }}/deploy-with-{{ provider | default('lago') }}.yml"
+- import_playbook: "{{ playbook_dir }}/playbooks/utils/configure-std-ci-repos.yml"
+  when: std_ci_yum_repos is defined
 - import_playbook: "{{ playbook_dir }}/playbooks/cluster/{{ cluster_type | default('openshift') }}/config.yml"
 - import_playbook: "{{ playbook_dir }}/install-kubevirt-release.yml"

--- a/playbooks/utils/configure-std-ci-repos.yml
+++ b/playbooks/utils/configure-std-ci-repos.yml
@@ -1,0 +1,7 @@
+- name: Configure std-ci repos
+  hosts: all
+  tasks:
+  - name: Configure std-ci repos
+    copy:
+      src: "{{ std_ci_yum_repos }}"
+      dest: "/etc/yum.repos.d/{{ std_ci_yum_repos | basename }}.repo"


### PR DESCRIPTION
- When $STD_CI_YUMREPOS environmet variable is defined, the VMs
  will be configured with the Centos repos that std-ci mirrors.

- RPM installation from the mirrors is faster (the Jenkins slave and the
  mirrors server aer in the same DC.

- It will mitigate errors which occurs when Centos' repos are not
  available.

closes https://github.com/kubevirt/kubevirt-ansible/issues/82
part of https://github.com/kubevirt/kubevirt-ansible/issues/44

Signed-off-by: gbenhaim <galbh2@gmail.com>