### PR TITLE
Fix role kubernetes-node not found

### DIFF
--- a/playbooks/cluster/kubernetes/config.yml
+++ b/playbooks/cluster/kubernetes/config.yml
@@ -17,4 +17,4 @@
 - hosts: nodes
   remote_user: root
   roles:
-    - "{{ playbook_dir }}/kubernetes/roles/node"
+    - kubernetes-node


### PR DESCRIPTION
Also use the same role path for role prerequisites and master.

Signed-off-by: Guohua Ouyang <guohuaouyang@gmail.com>