### PR TITLE
Clone openshift-ansible to HOME dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ $ export ANSIBLE_ROLES_PATH=$HOME/galaxy-roles
 For OpenShift deployment clone [**OpenShift Ansible**][openshift-ansible-project]
 
 ```bash
-$ git clone -b release-3.7 https://github.com/openshift/openshift-ansible
+$ git clone -b release-3.7 https://github.com/openshift/openshift-ansible $HOME/openshift-ansible
+$ export ANSIBLE_ROLES_PATH=$HOME/openshift-ansible
 ```
 
 ## Cluster configuration
@@ -87,8 +88,7 @@ Follow [docker-storage-setup] documentation for more details.
 
 ```bash
 $ ansible-playbook -i inventory \
-    -e "openshift_ansible_dir=openshift-ansible/ \
-    openshift_playbook_path=playbooks/byo/config.yml \
+    -e "openshift_playbook_path=playbooks/byo/config.yml \
     openshift_ver=3.7" playbooks/cluster/openshift/config.yml
 ```
 where

--- a/playbooks/cluster/openshift/config.yml
+++ b/playbooks/cluster/openshift/config.yml
@@ -54,7 +54,7 @@
 
     - name: Include openshift_facts module
       import_role:
-        name: "{{ openshift_ansible_dir }}/roles/openshift_facts"
+        name: "{{ lookup('env','openshift_ansible_dir') }}/roles/openshift_facts"
 
     - name: Load openshift facts
       openshift_facts:
@@ -81,8 +81,8 @@
         enabled: yes
         name: docker
 
-- import_playbook: "{{ openshift_ansible_dir }}/playbooks/prerequisites.yml"
-- import_playbook: "{{ openshift_ansible_dir | join_paths(openshift_playbook_path | default('playbooks/byo/config.yml')) }}"
+- import_playbook: "{{ lookup('env','openshift_ansible_dir') }}/playbooks/prerequisites.yml"
+- import_playbook: "{{ lookup('env','openshift_ansible_dir') | join_paths(openshift_playbook_path | default('playbooks/byo/config.yml')) }}"
 
 - hosts: masters
   tasks:


### PR DESCRIPTION
Place openshift-ansible to HOME dir instead of kubevirt-ansible dir.
It can keep the kubevirt-ansible clean and easy to refer it.
Export openshift_ansible_dir so playbooks can use it by lookup this env
varible.

Fix #108

Signed-off-by: Guohua Ouyang <guohuaouyang@gmail.com>