### PR TITLE
[WIP] storage: Add a storage-demo role

### DIFF
--- a/playbooks/automation/check-patch.yml
+++ b/playbooks/automation/check-patch.yml
@@ -4,3 +4,4 @@
 - import_playbook: "{{ playbook_dir }}/../cluster/{{ cluster | default('openshift') }}/config.yml"
 - import_playbook: "{{ playbook_dir }}/../cluster-login.yml"
 - import_playbook: "{{ playbook_dir }}/../kubevirt.yml"
+- import_playbook: "{{ playbook_dir }}/../storage.yml"

--- a/playbooks/storage.yml
+++ b/playbooks/storage.yml
@@ -1,0 +1,22 @@
+---
+- hosts: localhost
+  vars:
+    storage_role: storage-demo
+  connection: local
+  gather_facts: False
+  # unset http_proxy. required for running in the CI
+  environment:
+    http_proxy: ""
+  roles:
+    - role: "{{ storage_role }}"
+
+- hosts: masters nodes
+  vars:
+    storage_role: storage-demo
+  gather_facts: False
+  # unset http_proxy. required for running in the CI
+  environment:
+    http_proxy: ""
+  roles:
+    - role: storage-demo-nodeconfig
+      when: storage_role == 'storage-demo'

--- a/roles/storage-demo-nodeconfig/README.md
+++ b/roles/storage-demo-nodeconfig/README.md
@@ -1,0 +1,9 @@
+# Ansible role: storage-demo-nodeconfig
+
+**Note: This role is not for production use.  All storage is erased any time**
+**the storage-demo pod is stopped.**
+
+This role configures the nodes in a cluster to work with the storage-demo role.
+Currently this means adjusting the firewall to allow ceph traffic to flow
+between nodes.  As such, this will only work on a cluster that is running
+iptables.

--- a/roles/storage-demo-nodeconfig/defaults/main.yml
+++ b/roles/storage-demo-nodeconfig/defaults/main.yml
@@ -1,0 +1,1 @@
+action: "provision"

--- a/roles/storage-demo-nodeconfig/tasks/deprovision.yml
+++ b/roles/storage-demo-nodeconfig/tasks/deprovision.yml
@@ -1,0 +1,19 @@
+---
+- name: "Remove rule: Allow ceph OSD traffic"
+  iptables:
+    state: absent
+    chain: INPUT
+    protocol: tcp
+    destination_port: 6789
+    jump: ACCEPT
+
+- name: "Remove rule: Allow ceph MDS traffic"
+  iptables:
+    state: absent
+    chain: INPUT
+    protocol: tcp
+    destination_port: 6800:7300
+    jump: ACCEPT
+
+- name: Save iptables configuration
+  command: iptables-save

--- a/roles/storage-demo-nodeconfig/tasks/main.yml
+++ b/roles/storage-demo-nodeconfig/tasks/main.yml
@@ -1,0 +1,2 @@
+---
+- include_tasks: "{{ action }}.yml"

--- a/roles/storage-demo-nodeconfig/tasks/provision.yml
+++ b/roles/storage-demo-nodeconfig/tasks/provision.yml
@@ -1,0 +1,19 @@
+---
+- name: Allow ceph OSD traffic
+  iptables:
+    action: insert
+    chain: INPUT
+    protocol: tcp
+    destination_port: 6789
+    jump: ACCEPT
+
+- name: Allow ceph MDS traffic
+  iptables:
+    action: insert
+    chain: INPUT
+    protocol: tcp
+    destination_port: 6800:7300
+    jump: ACCEPT
+
+- name: Save iptables configuration
+  command: iptables-save

--- a/roles/storage-demo/README.md
+++ b/roles/storage-demo/README.md
@@ -1,0 +1,21 @@
+# Ansible role: storage-demo
+
+**Note: This role is not for production use.  All storage is erased any time**
+**the storage-demo pod is stopped.**
+
+This role deploys a self-contained storage environment suitable for development
+and testing.  A single-instance ephemeral ceph cluster is created inside a pod.
+Cinder is deployed and connected to ceph.  A dynamic provisioner and related
+kubernetes resources are created to interface with the cluster.
+
+## Configuration parameters
+* **namespace**: The namespace into which the storage-demo components should be
+  installed
+* **cluster**: The type of cluster (openshift or kubernetes)
+* **cinder_provisioner_repo**: The repository containing the cinder provisioner
+* **cinder_provisioner_release**: The docker image tag to use for the cinder
+  provisioner
+* **action**: The action to perform.  Currently only 'provision' is supported
+* **storage_demo_template_dir**: The location of the deployment template file.
+  There is no need to change this value.
+  

--- a/roles/storage-demo/defaults/main.yml
+++ b/roles/storage-demo/defaults/main.yml
@@ -1,0 +1,7 @@
+namespace: "kube-system"
+cluster: "openshift"
+cinder_provisioner_repo: "quay.io/aglitke"
+cinder_provisioner_release: "sprint4"
+action: "provision"
+
+storage_demo_template_dir: "{{ role_path }}/templates"

--- a/roles/storage-demo/tasks/deprovision.yml
+++ b/roles/storage-demo/tasks/deprovision.yml
@@ -1,0 +1,11 @@
+---
+- set_fact:
+    storage_demo_node_hostname: "nohost"
+
+- name: Render storage-demo deployment yaml
+  template:
+    src: "{{ storage_demo_template_dir }}/storage-demo.yml"
+    dest: /tmp/storage-demo.yml
+
+- name: Delete storage-demo Resources
+  command: kubectl delete -f /tmp/storage-demo.yml --ignore-not-found

--- a/roles/storage-demo/tasks/main.yml
+++ b/roles/storage-demo/tasks/main.yml
@@ -1,0 +1,2 @@
+---
+- include_tasks: "{{ action }}.yml"

--- a/roles/storage-demo/tasks/provision.yml
+++ b/roles/storage-demo/tasks/provision.yml
@@ -1,0 +1,45 @@
+---
+- name: Login As Super User
+  command: "oc login -u {{ admin_user }} -p {{ admin_password }}"
+  when: cluster=="openshift"
+        and admin_user is defined
+        and admin_password is defined
+
+- name: Check if namespace {{ namespace }} exists
+  shell: kubectl get ns | grep -w {{ namespace }} | awk '{ print $1 }'
+  register: ns
+
+- name: Create {{ namespace }} namespace
+  shell: kubectl create namespace {{ namespace }}
+  when: ns.stdout != namespace
+
+- name: Check for storage-demo serviceaccount
+  command: kubectl get serviceaccount storage-demo -n {{ namespace }}
+  register: user
+  failed_when: user.rc > 1
+
+- name: Create storage-demo serviceaccount
+  command: kubectl create serviceaccount storage-demo -n {{ namespace }}
+  when: user.stdout == ""
+
+- name: Grant privileged access to storage-demo serviceaccount
+  command: oc adm policy add-scc-to-user privileged system:serviceaccount:{{ namespace }}:storage-demo
+  when: cluster=="openshift"
+
+- name: Select a target node
+  command: kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="Hostname")].address}'
+  register: node_hostname
+  when: storage_demo_node_hostname is not defined
+
+- name: Set the target node
+  set_fact:
+    storage_demo_node_hostname: "{{ node_hostname.stdout }}"
+  when: storage_demo_node_hostname is not defined
+
+- name: Render storage-demo deployment yaml
+  template:
+    src: "{{ storage_demo_template_dir }}/storage-demo.yml"
+    dest: /tmp/storage-demo.yml
+
+- name: Create storage-demo Resources
+  command: kubectl apply -f /tmp/storage-demo.yml

--- a/roles/storage-demo/templates/storage-demo.yml
+++ b/roles/storage-demo/templates/storage-demo.yml
@@ -1,0 +1,128 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: storage-demo-cluster-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  name: cluster-admin
+  kind: ClusterRole
+subjects:
+- kind: ServiceAccount
+  name: storage-demo
+  namespace: {{ namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: storage-demo-default-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  name: cluster-admin
+  kind: ClusterRole
+subjects:
+- kind: ServiceAccount
+  name: storage-demo
+  namespace: default
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: storage-demo
+  namespace: "{{ namespace }}"
+  labels:
+    app: storage-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: storage-demo
+  template:
+    metadata:
+      labels:
+        app: storage-demo
+    spec:
+      serviceAccountName: storage-demo
+      nodeSelector:
+          "kubernetes.io/hostname": "{{ storage_demo_node_hostname }}"
+      hostNetwork: true
+      containers:
+      - name: kraken
+        args: ["demo"]
+        env:
+        - name: MON_IP
+          value: "{{ storage_demo_node_hostname }}"
+        - name: CEPH_PUBLIC_NETWORK
+          value: "0.0.0.0/0"
+        - name: RGW_CIVETWEB_PORT
+          value: "81" # Don't clash with openshift
+        ports:
+          - containerPort: 6789
+            hostPort: 6789
+        image: ceph/demo
+        volumeMounts:
+        - name: cephvarlib
+          mountPath: /var/lib/ceph
+        - name: cephetc
+          mountPath: /etc/ceph
+      - name: mariadb
+        env:
+        - name: MYSQL_ROOT_PASSWORD
+          value: "password"
+        - name: MYSQL_DATABASE
+          value: "cinder"
+        - name: MYSQL_USER
+          value: "cinder"
+        - name: MYSQL_PASSWORD
+          value: "password"
+        image: mariadb
+        volumeMounts:
+        - name: mariadbdata
+          mountPath: "/var/lib/mysql"
+      - name: rabbitmq
+        image: rabbitmq
+      - name: cinder-api
+        image: kubevirtci/cinder:ocata
+        command: ["/scripts/cinder-api.sh"]
+        env:
+        - name: INIT_DB
+          value: "true"
+      - name: cinder-scheduler
+        image: kubevirtci/cinder:ocata
+        command: ["cinder-scheduler"]
+      - name: cinder-volume
+        image: kubevirtci/cinder:ocata
+        command: ["/scripts/ceph-service.sh"]
+        env:
+        - name: MON_IP
+          value: "{{ storage_demo_node_hostname }}"
+        volumeMounts:
+        - name: cephetc
+          mountPath: "/etc/ceph"
+      - name: cinder-provisioner
+        image: {{ cinder_provisioner_repo }}/standalone-cinder-provisioner:{{ cinder_provisioner_release }}
+        env:
+        - name: OS_CINDER_ENDPOINT
+          value: http://127.0.0.1:8776/v3
+      volumes:
+      - name: cephvarlib
+        emptyDir: {}
+      - name: cephetc
+        emptyDir: {}
+      - name: mariadbdata
+        emptyDir: {}
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1beta1
+metadata:
+  name: kubevirt
+provisioner: openstack.org/standalone-cinder
+parameters:
+  smartclone: "true"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kubevirt-cephx-secret
+type: "kubernetes.io/rbd"
+data:
+  key: QVFDMkI0SmE2MDgzT3hBQTdOR0dpb0xpR1lqOHlJTFpkYUI1T0E9PQo=


### PR DESCRIPTION
The storage-demo role deploys a self-contained ephemeral storage
environment consisting of a cider and ceph.  This should only be used
by developers.  All data stored will be lost when the storage-demo
statefulset is terminated.

Signed-off-by: Adam Litke <alitke@redhat.com>