### PR TITLE
Add storage-cns role

### DIFF
--- a/roles/storage-cns/README.md
+++ b/roles/storage-cns/README.md
@@ -1,0 +1,13 @@
+# Ansible role: storage-cns
+
+This role deploys cluster resources necessary for kubevirt to interface with
+CNS (glusterfs) storage.  This role assumes that CNS itself has already been
+installed.
+
+### Variables
+| Variable        | Default Value           | Description  |
+|:------------- |:-------------|:----- |
+| admin_user | _optional_ | User with cluster-admin permissions. Used in the APB |
+| admin_password | _optional_ | Password for cluster-admin user. Used in the APB |
+| cluster | openshift | The cluster we're running on |
+| action | provision | The action of provisioning or deprovisioning CNS add-ons |

--- a/roles/storage-cns/defaults/main.yml
+++ b/roles/storage-cns/defaults/main.yml
@@ -1,0 +1,3 @@
+cluster: "openshift"
+action: "provision"
+

--- a/roles/storage-cns/tasks/deprovision.yml
+++ b/roles/storage-cns/tasks/deprovision.yml
@@ -1,0 +1,14 @@
+---
+- name: Login As Super User
+  command: "oc login -u {{ admin_user }} -p {{ admin_password }}"
+  when: cluster=="openshift"
+        and admin_user is defined
+        and admin_password is defined
+
+- name: Render storage-cns deployment yaml
+  template:
+    src: storage-cns.yml
+    dest: /tmp/storage-cns.yml
+
+- name: Delete storage-cns Resources
+  command: kubectl delete -f /tmp/storage-cns.yml

--- a/roles/storage-cns/tasks/main.yml
+++ b/roles/storage-cns/tasks/main.yml
@@ -1,0 +1,2 @@
+---
+- include_tasks: "{{ action }}.yml"

--- a/roles/storage-cns/tasks/provision.yml
+++ b/roles/storage-cns/tasks/provision.yml
@@ -1,0 +1,14 @@
+---
+- name: Login As Super User
+  command: "oc login -u {{ admin_user }} -p {{ admin_password }}"
+  when: cluster=="openshift"
+        and admin_user is defined
+        and admin_password is defined
+
+- name: Render storage-cns deployment yaml
+  template:
+    src: storage-cns.yml
+    dest: /tmp/storage-cns.yml
+
+- name: Create storage-cns Resources
+  command: kubectl apply -f /tmp/storage-cns.yml

--- a/roles/storage-cns/templates/storage-cns.yml
+++ b/roles/storage-cns/templates/storage-cns.yml
@@ -1,0 +1,14 @@
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1beta1
+metadata:
+  name: kubevirt
+provisioner: kubernetes.io/glusterfs
+reclaimPolicy: Delete
+parameters:
+  # Enable this when CNS supports cloning
+  # smartclone: "true"
+  resturl: http://heketi-storage-app-storage.router.default.svc.cluster.local
+  restuser: admin
+  secretName: heketi-storage-admin-secret
+  secretNamespace: app-storage


### PR DESCRIPTION
Add a storage-cns role to connect kubevirt with existing CNS storage in
the cluster.  This role does not install CNS on a cluster.  It assumes
that CNS has been installed via one of the already supported
installation methods.

Signed-off-by: Adam Litke <alitke@redhat.com>