### PR TITLE
Temporary playbook to disable selinux

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ KubeVirt Ansible consists of a set of Ansible playbooks that deploy fully functi
 
 ## Contents
 
-* `atomation/`: CI scripts to verify the functionality of playbooks.
+* `automation/`: CI scripts to verify the functionality of playbooks.
 * `playbooks/`: Ansible playbooks to provision resources, deploy a cluster and install KubeVirt for various scenarios.
 * `roles/`: Roles to use in playbooks.
 * `vars/`: Variables to use in playbooks.

--- a/playbooks/README.md
+++ b/playbooks/README.md
@@ -109,6 +109,11 @@ indentified with the cluster using ```oc login```.
 
 Install KubeVirt on your OpenShift cluster.
 
+Before installing KubeVirt on an existing OpenShift cluster, ensure that SELinux is disabled on all hosts:
+```bash
+$ ansible-playbook -i inventory playbooks/selinux.yml
+```
+
 ```bash
 $ ansible-playbook -i localhost playbooks/kubevirt.yml -e@vars/all.yml
 ```

--- a/playbooks/selinux.yml
+++ b/playbooks/selinux.yml
@@ -1,0 +1,8 @@
+- hosts: all
+  gather_facts: no
+  vars:
+    selinux: "permissive"
+  tasks:
+    - name: "setenforce {{ selinux }}"
+      shell: "setenforce {{ selinux }}"
+      become: true


### PR DESCRIPTION
Currently SELinux permissive mode is required in order to run this early version of KubeVirt.

We will switch to enforcing mode once KubeVirt is more stable.