### PR TITLE
Fix task of remove firewalld package

### DIFF
--- a/roles/kubernetes-prerequisites/tasks/main.yml
+++ b/roles/kubernetes-prerequisites/tasks/main.yml
@@ -7,10 +7,6 @@
     policy: targeted
     state: permissive
 
-- name: remove firewalld package
-  package:
-    name: firewalld
-
 - name: stop and disable firewalld
   register: result
   service:


### PR DESCRIPTION
The previously PR is placing the remove firewalld task before stop and disable firewalld, it should be placed after that task.

Signed-off-by: Guohua Ouyang <guohuaouyang@gmail.com>