### PR TITLE
storage: cns and cdi idempotency fixes

### DIFF
--- a/roles/cdi/tasks/deprovision.yml
+++ b/roles/cdi/tasks/deprovision.yml
@@ -7,6 +7,9 @@
 - name: Delete {{ cdi_namespace }} ResourceQuota
   command: kubectl delete -f /tmp/cdi-deprovision-resourcequota.yml -n {{ cdi_namespace }} --ignore-not-found
 
+- name: Delete RBAC for CDI
+  shell: kubectl delete clusterrolebinding c-{{ cdi_namespace }}-default --ignore-not-found
+
 - name: Render CDI deprovision yaml
   template:
     src:  cdi-controller-deployment.yml

--- a/roles/cdi/tasks/provision.yml
+++ b/roles/cdi/tasks/provision.yml
@@ -18,8 +18,13 @@
   when: ns.stdout != cdi_namespace
         and cli.stdout == "oc"
 
+- name: Check if RBAC for CDI exists
+  shell: kubectl get clusterrolebinding | grep -w c-{{ cdi_namespace }}-default | awk '{ print $1 }'
+  register: rbac
+
 - name: Create RBAC for CDI
   shell: kubectl create clusterrolebinding c-{{ cdi_namespace }}-default --clusterrole=cluster-admin  --serviceaccount={{ cdi_namespace }}:default
+  when: rbac.stdout != "c-{{ cdi_namespace }}-default"
 
 - name: Render {{ cdi_namespace }} ResourceQuota deployment yaml
   template:

--- a/roles/storage-cns/tasks/deprovision.yml
+++ b/roles/storage-cns/tasks/deprovision.yml
@@ -11,4 +11,4 @@
     dest: /tmp/storage-cns.yml
 
 - name: Delete storage-cns Resources
-  command: kubectl delete -f /tmp/storage-cns.yml
+  command: kubectl delete -f /tmp/storage-cns.yml --ignore-not-found


### PR DESCRIPTION
It should be possible to provision storage multiple times in a row
without errors.  The same is true for deprovisioning.  Make the
following changes to fix idempotency:
- cdi: ignore not found error when deleting clusterrolebinding
- cdi: Only create the clusterrolebinding if it does not exist
- cns: ignore not found error when deleting storageclass

Signed-off-by: Adam Litke <alitke@redhat.com>