### PR TITLE
update deprovision task to delete role

### DIFF
--- a/roles/cdi/tasks/deprovision.yml
+++ b/roles/cdi/tasks/deprovision.yml
@@ -7,6 +7,9 @@
 - name: Delete {{ cdi_namespace }} ResourceQuota
   command: kubectl delete -f /tmp/cdi-deprovision-resourcequota.yml -n {{ cdi_namespace }} --ignore-not-found
 
+- name: Delete clusterrolebinding for c-{{ cdi_namespace }}-default if found
+  command: kubectl delete clusterrolebinding c-{{ cdi_namespace }}-default --ignore-not-found
+
 - name: Render CDI deprovision yaml
   template:
     src:  cdi-controller-deployment.yml

--- a/roles/cdi/templates/cdi-controller-deployment.yml
+++ b/roles/cdi/templates/cdi-controller-deployment.yml
@@ -15,7 +15,7 @@ spec:
       containers:
       - name: cdi-controller
         image: {{ repo_tag }}/import-controller:{{ release_tag }}
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         env:
           - name: OWN_NAMESPACE
             valueFrom:


### PR DESCRIPTION
@aglitke @rthallisey - can you take a look, as I was testing some stuff out, I noticed that we get an error if we run `provision` on cdi role and then `deprovision` and then `provision` again...so I added removing the clusterrolebinding in the deprovision and general ignore_errors in case someone manually does this by accident.