### PR TITLE
role kubevirt: fixed warning about using jinja in when stmt

### DIFF
--- a/roles/kubevirt/tasks/provision.yml
+++ b/roles/kubevirt/tasks/provision.yml
@@ -11,7 +11,7 @@
 
 - name: Create {{ namespace }} namespace
   shell: kubectl create namespace {{ namespace }}
-  when: ns.stdout != "{{ namespace }}"
+  when: ns.stdout != namespace
 
 - name: Add Privileged Policy
   command: "oc adm policy add-scc-to-user privileged -z {{ item }} -n {{ namespace }}"


### PR DESCRIPTION
TASK [kubevirt : Create kube-system namespace] *********************************
Wednesday 28 March 2018  12:17:17 +0000 (0:00:00.425)       0:00:03.108 *******
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: ns.stdout != "{{ namespace }}"

Signed-off-by: Lukas Bednar <lbednar@redhat.com>