### PR TITLE
Fix for Issue#158: Making kubevirt-ansible more idempotent

### DIFF
--- a/roles/cdi/tasks/provision.yml
+++ b/roles/cdi/tasks/provision.yml
@@ -18,8 +18,17 @@
   when: ns.stdout != cdi_namespace
         and cli.stdout == "oc"
 
+- name: Check if RBAC exists for CDI
+  shell: kubectl get clusterrolebinding c-{{ cdi_namespace }}-default
+  register: rbac_check
+  failed_when:
+  - '"NotFound" not in rbac_check.stderr'
+  - rbac_check.rc != 0
+
 - name: Create RBAC for CDI
   shell: kubectl create clusterrolebinding c-{{ cdi_namespace }}-default --clusterrole=cluster-admin  --serviceaccount={{ cdi_namespace }}:default
+  when:
+  - rbac_check.rc == 1
 
 - name: Render {{ cdi_namespace }} ResourceQuota deployment yaml
   template:


### PR DESCRIPTION
With this change, kubevirt-ansible will not error out if the
clusterrolebinding already exist in the cluster.

https://github.com/kubevirt/kubevirt-ansible/issues/158