### PR TITLE
GlusterFS: Updates to StorageClass

### DIFF
--- a/roles/storage-glusterfs/tasks/provision.yml
+++ b/roles/storage-glusterfs/tasks/provision.yml
@@ -24,6 +24,13 @@
     heketi_url: "{{ route_cmd.stdout }}"
   when: route_cmd is defined
 
+- name: Get heketi admin key
+  command: "oc get secret {{ heketi_secret_name }} -n {{ namespace }} -o jsonpath='{.data.key}'"
+  register: key_cmd
+
+- set_fact:
+    heketi_admin_key: "{{ key_cmd.stdout }}"
+
 - name: Render storage-glusterfs deployment yaml
   template:
     src: storage-glusterfs.yml.j2

--- a/roles/storage-glusterfs/templates/storage-glusterfs.yml.j2
+++ b/roles/storage-glusterfs/templates/storage-glusterfs.yml.j2
@@ -1,4 +1,17 @@
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kubevirt-heketi-secret
+  namespace: {{ namespace }}
+data:
+  key: {{ heketi_admin_key }}
+{% if external_provisioner %}
+type: gluster.org/glusterfile
+{% else %}
+type: kubernetes.io/glusterfs
+{% endif %}
+---
 kind: StorageClass
 apiVersion: storage.k8s.io/v1beta1
 metadata:
@@ -12,6 +25,6 @@ reclaimPolicy: Delete
 parameters:
   resturl: "http://{{ heketi_url | default(omit) }}"
   restuser: admin
-  secretName: "{{ heketi_secret_name }}"
+  secretName: "kubevirt-heketi-secret"
   secretNamespace: "{{ namespace }}"
   volumeoptions: "group virt"

--- a/roles/storage-glusterfs/templates/storage-glusterfs.yml.j2
+++ b/roles/storage-glusterfs/templates/storage-glusterfs.yml.j2
@@ -14,3 +14,4 @@ parameters:
   restuser: admin
   secretName: "{{ heketi_secret_name }}"
   secretNamespace: "{{ namespace }}"
+  volumeoptions: "group virt"


### PR DESCRIPTION
This PR contains two critical updates to the StorageClass created by the sotrage-glusterfs role:

* Sets the GlusterFs volume option "group virt" to enable beat-practice configurations for virtualization workloads
* Creates a separate Secret for use by the kubevirt StorageClass

Depends on #175 

Signed-off-by: Jose A. Rivera <jarrpa@redhat.com>
