### PR TITLE
Enable selinux for openshift cluster

### DIFF
--- a/playbooks/README.md
+++ b/playbooks/README.md
@@ -141,6 +141,17 @@ create the StorageClass.
 
 **Cinder**
 
+### SELinux
+
+In case you are experiencing permission or SELinux issues,
+you can disable SELinux by running following playbook.
+
+```bash
+$ ansible-playbook -i inventory -e "selinux=permissive" playbooks/selinux.yml
+```
+
+Be sure to update the [inventory file](../inventory) according to your OpenSift cluster configuration or use the file you used to deploy the cluster.
+
 [container_runtime]: https://github.com/openshift/openshift-ansible/tree/master/roles/container_runtime
 [docker-storage-setup]: https://docs.openshift.org/latest/install_config/install/host_preparation.html#configuring-docker-storage
 [container_runtime-defaults]: https://github.com/openshift/openshift-ansible/blob/master/roles/container_runtime/defaults/main.yml

--- a/playbooks/cluster/openshift/config.yml
+++ b/playbooks/cluster/openshift/config.yml
@@ -26,13 +26,13 @@
       import_role:
         name: lib_utils
 
-    - name: set SELinux to permissive mode
-      command: setenforce 0
+    - name: set SELinux to enforcing mode
+      command: setenforce 1
 
     - name: set SELinux to permissive mode under configuration file
       selinux:
         policy: targeted
-        state: permissive
+        state: enforcing
 
     - name: stop and disable firewalld
       register: result

--- a/playbooks/selinux.yml
+++ b/playbooks/selinux.yml
@@ -1,0 +1,8 @@
+- hosts: all
+  gather_facts: no
+  vars:
+    selinux: "enforcing"
+  tasks:
+    - name: "setenforce {{ selinux }}"
+      shell: "setenforce {{ selinux }}"
+      become: true


### PR DESCRIPTION
Since kubevirt/kubevirt#639 was merged, we should be able to run
kubevirt with SELinux enabled, on all cluster nodes.

Signed-off-by: Lukas Bednar <lbednar@redhat.com>