### PR TITLE
Make the kubevirt role idempotent.

### DIFF
--- a/roles/kubevirt/tasks/provision.yml
+++ b/roles/kubevirt/tasks/provision.yml
@@ -65,7 +65,7 @@
   when: cluster == "openshift"
 
 - name: Create default VM templates in OpenShift Namespace
-  shell: "oc create -f /tmp/kubevirt-{{ version }}/cluster/{{ item }}.yaml -n openshift"
+  shell: "oc apply -f /tmp/kubevirt-{{ version }}/cluster/{{ item }}.yaml -n openshift"
   with_items:
     - "{{ default_vm_templates }}"
   when: cluster == "openshift"


### PR DESCRIPTION
This change will resolve a bug where the kubevirt role would fail while trying
to create a resource that already exists.

Sort of in reference to #158. Caught another one while testing the hosts changes.