### PR TITLE
Add APB entrypoint

### DIFF
--- a/playbooks/apb.yml
+++ b/playbooks/apb.yml
@@ -1,0 +1,10 @@
+- hosts: localhost
+  connection: local
+  gather_facts: False
+  # unset http_proxy. required for running in the CI
+  environment:
+    http_proxy: ""
+  roles:
+    - role: kubevirt
+    - role: "{{ storage_role }}"
+    - role: cdi


### PR DESCRIPTION
The use of kubevirt-ansible roles is different when being done in an APB
as opposed to CI or as an end user.  The APB runs in a pod on the
infrastructure so the host is always localhost.  Certain roles/plays
cannot be executed in this context (ie. storage-demo).  Create a special
apb entrypoint where we can customize the flow for this use case.

The first material change to the flow is needed to fix a broken storage
deployment.  Instead of including the storage.yml playbook we should
just include the correct storage role directly.

Fixes storage and cdi install once the apb is adjusted to use apb.yml as
the entrypoint.

Signed-off-by: Adam Litke <alitke@redhat.com>