### PR TITLE
Fix heketi route discovery

### DIFF
--- a/roles/storage-glusterfs/tasks/provision.yml
+++ b/roles/storage-glusterfs/tasks/provision.yml
@@ -9,7 +9,7 @@
     glusterfs_name_label: "{{ glusterfs_name }}{% if glusterfs_name %}-{% endif %}"
 
 - name: Determine the heketi route
-  command: "oc get route -n {{ glusterfs_namespace }} -l heketi={{ glusterfs_name_label }}route -o jsonpath='{.spec.host}'"
+  command: "oc get route -n {{ glusterfs_namespace }} -l heketi={{ glusterfs_name_label }}route -o jsonpath='{.items[0].spec.host}'"
   register: route_cmd
   when:
     - cluster == 'openshift'


### PR DESCRIPTION
When grabbing the heketi route the json data is in an array.  Update the
jsonpath expression to traverse this array.

Signed-off-by: Adam Litke <alitke@redhat.com>