### PR TITLE
Install kubernetes-modules directly from github

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -3,4 +3,6 @@
   version: master
   name: openshift-contrib
 
-- src: ansible.kubernetes-modules
+- src: https://github.com/ansible/ansible-kubernetes-modules.git
+  version: v0.3.1-5
+  name: ansible.kubernetes-modules


### PR DESCRIPTION
From some reason kubernetes-modules disappeared from ansible galaxy.
So pulling kubernetes-modules from github instead.

Fixes: #203

Signed-off-by: Lukas Bednar <lbednar@redhat.com>