### PR TITLE
Update openshift-ansible modules

### DIFF
--- a/automation/check-patch.openshift_3-9.sh
+++ b/automation/check-patch.openshift_3-9.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 
 export OPENSHIFT_VERSION="3.9"
-export ANSIBLE_MODULES_VERSION="openshift-ansible-3.9.0-0.40.0"
+export ANSIBLE_MODULES_VERSION="openshift-ansible-3.9.30-1"
 export OPENSHIFT_PLAYBOOK_PATH="playbooks/deploy_cluster.yml"
 "${0%/*}/check-patch.sh" "$@"

--- a/automation/check-patch.packages
+++ b/automation/check-patch.packages
@@ -1,4 +1,4 @@
 lago
-ansible-2.4.2.0-2.el7
+ansible-2.5.3-1.el7
 origin-clients
 docker

--- a/playbooks/README.md
+++ b/playbooks/README.md
@@ -7,7 +7,7 @@ This repository provides a collection of playbooks to
 
 > **NOTE:** Checked box means that playbook is working and supported, unchecked box means that playbook needs stabilization.
 
-**Tested on CentOS Linux release 7.5 (Core), OpenShift 3.9 and Ansible 2.4.2**
+**Tested on CentOS Linux release 7.5 (Core), OpenShift 3.9 and Ansible 2.5.3**
 
 ## Requirements
 

--- a/playbooks/cluster/openshift/vars/3.9.yml
+++ b/playbooks/cluster/openshift/vars/3.9.yml
@@ -1,4 +1,4 @@
-openshift_image_tag: v3.9.0-alpha.4
+openshift_image_tag: v3.9.0
 openshift_service_catalog_image_version: "{{ openshift_image_tag }}"
 container_images:
   - "openshift/origin:{{ openshift_image_tag }}"

--- a/playbooks/cluster/openshift/vars/3.9.yml
+++ b/playbooks/cluster/openshift/vars/3.9.yml
@@ -5,6 +5,7 @@ container_images:
   - "openshift/node:{{ openshift_image_tag }}"
   - "openshift/openvswitch:{{ openshift_image_tag }}"
   - "openshift/origin-service-catalog:{{ openshift_image_tag }}"
+  - "openshift/origin-web-console:{{ openshift_image_tag }}"
   - "ansibleplaybookbundle/origin-ansible-service-broker:latest"
   - "quay.io/coreos/etcd:latest"
   - "registry.fedoraproject.org/latest/etcd"


### PR DESCRIPTION
#### Update openshift-ansible modules
- Use "openshift-ansible-3.9.30-1" tag for deploying openshift 3.9
- Use "ansible-2.5.1-1.el7" - required by the modules mentioned above.

#### Pre pull "origin-web-console" container

#### Update OC 3.9 image tag to "v3.9.0"

"v3.9.0" isn't static, and is being updated approximately once a week.
This is not the optimal solution for CI, but we need to use up to date
images.

Signed-off-by: gbenhaim <galbh2@gmail.com>