### PR TITLE
Deprecate Openshit 3.7 CI

### DIFF
--- a/automation/check-patch.openshift_3-7.mounts
+++ b/automation/check-patch.openshift_3-7.mounts
@@ -1,1 +1,0 @@
-check-patch.mounts

--- a/automation/check-patch.openshift_3-7.packages
+++ b/automation/check-patch.openshift_3-7.packages
@@ -1,1 +1,0 @@
-check-patch.packages

--- a/automation/check-patch.openshift_3-7.repos
+++ b/automation/check-patch.openshift_3-7.repos
@@ -1,1 +1,0 @@
-check-patch.repos

--- a/automation/check-patch.openshift_3-7.sh
+++ b/automation/check-patch.openshift_3-7.sh
@@ -1,6 +1,0 @@
-#!/bin/bash -ex
-
-export OPENSHIFT_VERSION="3.7"
-export ANSIBLE_MODULES_VERSION="openshift-ansible-3.7.29-1"
-export OPENSHIFT_PLAYBOOK_PATH="playbooks/byo/config.yml"
-"${0%/*}/check-patch.sh"

--- a/automation/check-patch.openshift_3-7.yumrepos
+++ b/automation/check-patch.openshift_3-7.yumrepos
@@ -1,1 +1,0 @@
-check-patch.yumrepos

--- a/inventory
+++ b/inventory
@@ -6,7 +6,7 @@ etcd
 [OSEv3:vars]
 openshift_deployment_type=origin
 containerized=true
-openshift_image_tag=v3.7.0
+openshift_image_tag=v3.9.0
 openshift_clock_enabled=true
 ansible_ssh_user=root
 openshift_master_identity_providers=[{'name': 'allow_all_auth', 'login': 'true', 'challenge': 'true', 'kind': 'AllowAllPasswordIdentityProvider'}]

--- a/playbooks/README.md
+++ b/playbooks/README.md
@@ -7,7 +7,7 @@ This repository provides a collection of playbooks to
 
 > **NOTE:** Checked box means that playbook is working and supported, unchecked box means that playbook needs stabilization.
 
-**Tested on CentOS Linux release 7.4 (Core), OpenShift 3.7, OpenShift 3.9 and Ansible 2.4.2**
+**Tested on CentOS Linux release 7.4 (Core), OpenShift 3.9 and Ansible 2.4.2**
 
 ## Requirements
 

--- a/stdci.yaml
+++ b/stdci.yaml
@@ -1,5 +1,4 @@
 substage:
-  - openshift_3-7
   - openshift_3-9
 
 runtime_requirements:


### PR DESCRIPTION
KubeVirt is targeted for Kubernetes 1.9, so there is
no need to test on Openshift 3.7 that uses K8S 1.7

closes https://github.com/kubevirt/kubevirt-ansible/issues/216

Signed-off-by: gbenhaim <galbh2@gmail.com>