### PR TITLE
Fix heketi_url determination when cluster is not openshift

### DIFF
--- a/roles/storage-glusterfs/tasks/deprovision.yml
+++ b/roles/storage-glusterfs/tasks/deprovision.yml
@@ -9,7 +9,10 @@
     glusterfs_name_label: "{{ glusterfs_name }}{% if glusterfs_name %}-{% endif %}"
 
 - name: Determine the heketi route
-  command: "oc get route -n {{ glusterfs_namespace }} -l heketi={{ glusterfs_name_label }}route -o jsonpath='{.items[0].spec.host}'"
+  command: > 
+    oc get route -n {{ glusterfs_namespace }} 
+    -l heketi={{ glusterfs_name_label }}route 
+    -o jsonpath='{.items[0].spec.host}'
   register: route_cmd
   when:
     - cluster == 'openshift'
@@ -22,14 +25,20 @@
     - route_cmd is defined
 
 - name: Determine the heketi route for k8s, IP
-  command: "kubectl get pod -n {{ glusterfs_namespace }} -l heketi={{ glusterfs_name_label }}pod -o jsonpath='{.items[0].status.podIP}'"
+  command: >
+    kubectl get pod -n {{ glusterfs_namespace }} 
+    -l heketi={{ glusterfs_name_label }}pod 
+    -o jsonpath='{.items[0].status.podIP}'
   register: heketi_pod_ip
   when:
     - cluster == 'kubernetes'
     - heketi_url is not defined
 
 - name: Determine the heketi route for k8s, port
-  command: "kubectl get pod -n {{ glusterfs_namespace }} -l heketi={{ glusterfs_name_label }}pod -o jsonpath='{.items[0].spec.containers[0].ports[0].containerPort}'"
+  command: > 
+    kubectl get pod -n {{ glusterfs_namespace }} 
+    -l heketi={{ glusterfs_name_label }}pod 
+    -o jsonpath='{.items[0].spec.containers[0].ports[0].containerPort}'
   register: heketi_pod_port
   when:
     - cluster == 'kubernetes'
@@ -44,7 +53,11 @@
     - heketi_pod_port is defined
 
 - name: Get heketi admin key
-  shell: "kubectl get pod -n {{ glusterfs_namespace }} -l heketi={{ glusterfs_name_label }}pod -o jsonpath='{.items[0].spec.containers[0].env[?(@.name==\"HEKETI_ADMIN_KEY\")].value}' | base64 -"
+  shell: > 
+    kubectl get pod -n {{ glusterfs_namespace }} 
+    -l heketi={{ glusterfs_name_label }}pod 
+    -o jsonpath='{.items[0].spec.containers[0].env[?(@.name==\"HEKETI_ADMIN_KEY\")].value}' 
+    | base64 -
   register: key_cmd
   when: heketi_admin_key is not defined
 

--- a/roles/storage-glusterfs/tasks/deprovision.yml
+++ b/roles/storage-glusterfs/tasks/deprovision.yml
@@ -17,7 +17,31 @@
 
 - set_fact:
     heketi_url: "{{ route_cmd.stdout }}"
-  when: route_cmd is defined
+  when:
+    - cluster == 'openshift'
+    - route_cmd is defined
+
+- name: Determine the heketi route for k8s, IP
+  command: "kubectl get pod -n {{ glusterfs_namespace }} -l heketi={{ glusterfs_name_label }}pod -o jsonpath='{.items[0].status.podIP}'"
+  register: heketi_pod_ip
+  when:
+    - cluster == 'kubernetes'
+    - heketi_url is not defined
+
+- name: Determine the heketi route for k8s, port
+  command: "kubectl get pod -n {{ glusterfs_namespace }} -l heketi={{ glusterfs_name_label }}pod -o jsonpath='{.items[0].spec.containers[0].ports[0].containerPort}'"
+  register: heketi_pod_port
+  when:
+    - cluster == 'kubernetes'
+    - heketi_url is not defined
+
+- set_fact:
+    heketi_url: "{{ heketi_pod_ip.stdout }}:{{ heketi_pod_port.stdout }}"
+  when:
+    - cluster == 'kubernetes'
+    - heketi_url is not defined
+    - heketi_pod_ip is defined
+    - heketi_pod_port is defined
 
 - name: Get heketi admin key
   shell: "kubectl get pod -n {{ glusterfs_namespace }} -l heketi={{ glusterfs_name_label }}pod -o jsonpath='{.items[0].spec.containers[0].env[?(@.name==\"HEKETI_ADMIN_KEY\")].value}' | base64 -"

--- a/roles/storage-glusterfs/tasks/provision.yml
+++ b/roles/storage-glusterfs/tasks/provision.yml
@@ -17,8 +17,32 @@
 
 - set_fact:
     heketi_url: "{{ route_cmd.stdout }}"
-  when: route_cmd is defined
+  when:
+    - cluster == 'openshift'
+    - route_cmd is defined
 
+- name: Determine the heketi route for k8s, IP
+  command: "kubectl get pod -n {{ glusterfs_namespace }} -l heketi={{ glusterfs_name_label }}pod -o jsonpath='{.items[0].status.podIP}'"
+  register: heketi_pod_ip
+  when:
+    - cluster == 'k8s'
+    - heketi_url is not defined
+
+- name: Determine the heketi route for k8s, port
+  command: "kubectl get pod -n {{ glusterfs_namespace }} -l heketi={{ glusterfs_name_label }}pod -o jsonpath='{.items[0].spec.containers[0].ports[0].containerPort}'"
+  register: heketi_pod_port
+  when:
+    - cluster == 'k8s'
+    - heketi_url is not defined
+
+- set_fact:
+    heketi_url: "http://{{ heketi_pod_ip.stdout }}:{{ heketi_pod_port.stdout }}"
+  when:
+    - cluster == 'k8s'
+    - heketi_url is not defined
+    - heketi_pod_ip is defined
+    - heketi_pod_port is defined
+    
 - name: Get heketi admin key
   shell: "kubectl get pod -n {{ glusterfs_namespace }} -l heketi={{ glusterfs_name_label }}pod -o jsonpath='{.items[0].spec.containers[0].env[?(@.name==\"HEKETI_ADMIN_KEY\")].value}' | base64 -"
   register: key_cmd

--- a/roles/storage-glusterfs/tasks/provision.yml
+++ b/roles/storage-glusterfs/tasks/provision.yml
@@ -25,20 +25,20 @@
   command: "kubectl get pod -n {{ glusterfs_namespace }} -l heketi={{ glusterfs_name_label }}pod -o jsonpath='{.items[0].status.podIP}'"
   register: heketi_pod_ip
   when:
-    - cluster == 'k8s'
+    - cluster == 'kubernetes'
     - heketi_url is not defined
 
 - name: Determine the heketi route for k8s, port
   command: "kubectl get pod -n {{ glusterfs_namespace }} -l heketi={{ glusterfs_name_label }}pod -o jsonpath='{.items[0].spec.containers[0].ports[0].containerPort}'"
   register: heketi_pod_port
   when:
-    - cluster == 'k8s'
+    - cluster == 'kubernetes'
     - heketi_url is not defined
 
 - set_fact:
     heketi_url: "http://{{ heketi_pod_ip.stdout }}:{{ heketi_pod_port.stdout }}"
   when:
-    - cluster == 'k8s'
+    - cluster == 'kubernetes'
     - heketi_url is not defined
     - heketi_pod_ip is defined
     - heketi_pod_port is defined

--- a/roles/storage-glusterfs/tasks/provision.yml
+++ b/roles/storage-glusterfs/tasks/provision.yml
@@ -36,7 +36,7 @@
     - heketi_url is not defined
 
 - set_fact:
-    heketi_url: "http://{{ heketi_pod_ip.stdout }}:{{ heketi_pod_port.stdout }}"
+    heketi_url: "{{ heketi_pod_ip.stdout }}:{{ heketi_pod_port.stdout }}"
   when:
     - cluster == 'kubernetes'
     - heketi_url is not defined

--- a/roles/storage-glusterfs/tasks/provision.yml
+++ b/roles/storage-glusterfs/tasks/provision.yml
@@ -9,7 +9,10 @@
     glusterfs_name_label: "{{ glusterfs_name }}{% if glusterfs_name %}-{% endif %}"
 
 - name: Determine the heketi route
-  command: "oc get route -n {{ glusterfs_namespace }} -l heketi={{ glusterfs_name_label }}route -o jsonpath='{.items[0].spec.host}'"
+  command: > 
+    oc get route -n {{ glusterfs_namespace }} 
+    -l heketi={{ glusterfs_name_label }}route 
+    -o jsonpath='{.items[0].spec.host}'
   register: route_cmd
   when:
     - cluster == 'openshift'
@@ -22,14 +25,20 @@
     - route_cmd is defined
 
 - name: Determine the heketi route for k8s, IP
-  command: "kubectl get pod -n {{ glusterfs_namespace }} -l heketi={{ glusterfs_name_label }}pod -o jsonpath='{.items[0].status.podIP}'"
+  command: > 
+    kubectl get pod -n {{ glusterfs_namespace }} 
+    -l heketi={{ glusterfs_name_label }}pod 
+    -o jsonpath='{.items[0].status.podIP}'
   register: heketi_pod_ip
   when:
     - cluster == 'kubernetes'
     - heketi_url is not defined
 
 - name: Determine the heketi route for k8s, port
-  command: "kubectl get pod -n {{ glusterfs_namespace }} -l heketi={{ glusterfs_name_label }}pod -o jsonpath='{.items[0].spec.containers[0].ports[0].containerPort}'"
+  command: > 
+    kubectl get pod -n {{ glusterfs_namespace }} 
+    -l heketi={{ glusterfs_name_label }}pod 
+    -o jsonpath='{.items[0].spec.containers[0].ports[0].containerPort}'
   register: heketi_pod_port
   when:
     - cluster == 'kubernetes'
@@ -44,7 +53,11 @@
     - heketi_pod_port is defined
     
 - name: Get heketi admin key
-  shell: "kubectl get pod -n {{ glusterfs_namespace }} -l heketi={{ glusterfs_name_label }}pod -o jsonpath='{.items[0].spec.containers[0].env[?(@.name==\"HEKETI_ADMIN_KEY\")].value}' | base64 -"
+  shell: > 
+    kubectl get pod -n {{ glusterfs_namespace }} 
+    -l heketi={{ glusterfs_name_label }}pod 
+    -o jsonpath='{.items[0].spec.containers[0].env[?(@.name==\"HEKETI_ADMIN_KEY\")].value}' 
+    | base64 -
   register: key_cmd
   when: heketi_admin_key is not defined
 


### PR DESCRIPTION
The set_fact step fails on upstream k8s cluster because route_cmd
appears to be still defined even though the previous step that
registers route_cmd does not run.

The patch adds addition tasks to find the heketi_url for upstream
k8s where the oc command is not available.

Fixes: https://github.com/kubevirt/kubevirt-ansible/issues/219