### PR TITLE
Add a DNS record for heketi

### DIFF
--- a/automation/check-patch.sh
+++ b/automation/check-patch.sh
@@ -115,7 +115,7 @@ run() {
     local provider="${PROVIDER:-lago}"
     local args=("prefix=$run_path")
     local inventory_file="$(realpath inventory)"
-    local storage_role="${STORAGE_ROLE:-storage-none}"
+    local storage_role="${STORAGE_ROLE:-storage-glusterfs}"
 
     set_params
     install_requirements

--- a/inventory
+++ b/inventory
@@ -15,6 +15,8 @@ openshift_enable_excluders=false
 template_service_broker_install=false
 openshift_use_manageiq=false
 openshift_install_examples=false
+# Domain name that will be used by the Openshift router
+openshift_master_default_subdomain=cloudapps.example.com
 
 # Enabling KubeVirt Admission Controller (https://www.kubevirt.io/user-guide/#/installation/api-validation?id=kubevirt-api-validation)
 openshift_master_admission_plugin_config={"ValidatingAdmissionWebhook":{"configuration":{"kind": "DefaultAdmissionConfig","apiVersion": "v1","disable": false}},"MutatingAdmissionWebhook":{"configuration":{"kind": "DefaultAdmissionConfig","apiVersion": "v1","disable": false}}}

--- a/playbooks/cluster/openshift/README.md
+++ b/playbooks/cluster/openshift/README.md
@@ -8,4 +8,4 @@ Create an OpenShift Cluster
 | kubevirt_openshift_version| 3.7| <ul><li>3.7</li><li>3.9</li></ul>|OpenShift cluster version.|
 | openshift_ansible_dir | openshift-ansible | |Path to the openshift-ansible directory.|
 | openshift_playbook_path | playbooks/byo/config.yml |<ul><li>playbooks/byo/config.yml</li><li>playbooks/deploy_cluster.yml</li></ul>|Path to the OpenShift deploy playbook. <br>3.7: **playbooks/byo/config.yml**<br>3.9: **playbooks/deploy_cluster.yml**|
-| storage_role | | <ul><li>storage-glusterfs</li></ul> | Storage flavor to deploy in the cluster. Don't forget to add gluster nodes in the [inventory file](https://github.com/kubevirt/kubevirt-ansible/blob/master/inventory).|
+| storage_role | | <ul><li>storage-glusterfs</li></ul> | Storage flavor to deploy in the cluster. Don't forget to add gluster nodes in the [inventory file](https://github.com/kubevirt/kubevirt-ansible/blob/master/inventory). For OpenShift, you will also need to have DNS configured such that `heketi-{{ glusterfs_name }}-{{ glusterfs_namespace }}.{{ openshift_master_default_subdomain }}` resolves to the IP address of a node running an OpenShift router.|

--- a/playbooks/provider/lago/LagoInitFile.yml.j2
+++ b/playbooks/provider/lago/LagoInitFile.yml.j2
@@ -19,8 +19,6 @@ host-settings: &nodes-settings
     groups: [nodes]
 {% endif %}
     memory: 2047
-    nics:
-      - net: lago-management-network
     disks:
       - template_name: el7.5-base
         type: template
@@ -52,7 +50,8 @@ domains:
 {% endif %}
     memory: 4096
     nics:
-      - net: lago-management-network
+      - ip: 192.168.200.2
+        net: lago-management-network
     disks:
       - template_name: el7.5-base
         type: template
@@ -82,12 +81,23 @@ domains:
 
   lago-node0:
     <<: *nodes-settings
+    nics:
+      - ip: 192.168.200.3
+        net: lago-management-network
 
   lago-node1:
     <<: *nodes-settings
+    nics:
+      - ip: 192.168.200.4
+        net: lago-management-network
 
 nets:
   lago-management-network:
     <<: *nat-settings
     management: true
     dns_domain_name: lago.local
+    gw: 192.168.200.1
+{% if storage_role|default('') == 'storage-glusterfs' %}
+    dns_records:
+      heketi-storage-app-storage.cloudapps.example.com: 192.168.200.3
+{% endif %}


### PR DESCRIPTION
- Set Openshift's router domain name to "cloudapps.example.com".

- Use static IP for Lago's VMs.

- Add a DNS recored that translates
  "heketi-storage-app-storage.cloudapps.example.com" to the IP of the
  node which runs Openshift's router.

-  Set "storge-glusterfs" as the default storage role

This fix has some drawbacks:

- If a different provider will be used, new code the configure/deploys a
  DNS server should be added.

- The DNS entry applies only to the "heketi" service, since wildcard DNS
  entries are not supported by Libvirt (which create the DNS server).

- Changes to the name of Gluster's namespace or to the router's domain
  name will require a change in LagoInitFile.

Signed-off-by: gbenhaim <galbh2@gmail.com>