### PR TITLE
Improve performance

### DIFF
--- a/automation/check-patch.mounts
+++ b/automation/check-patch.mounts
@@ -2,3 +2,4 @@
 /var/lib/libvirt/boot
 /var/lib/lago
 /dev/shm
+/var/run/docker.sock:/var/run/docker.sock

--- a/automation/check-patch.packages
+++ b/automation/check-patch.packages
@@ -1,3 +1,4 @@
 lago
 ansible-2.4.2.0-2.el7
 origin-clients
+docker

--- a/playbooks/cluster/openshift/config.yml
+++ b/playbooks/cluster/openshift/config.yml
@@ -1,12 +1,13 @@
 ---
 - hosts: all
   remote_user: root
+  strategy: free
   vars:
     epel_release_rpm_url: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
     openshift_ansible_dir: "openshift-ansible/"
     openshift_playbook_path: "playbooks/byo/config.yml"
     kubevirt_openshift_version: "3.7"
-  pre_tasks:
+  tasks:
     - name: include_vars
       include_vars:
         file: "{{ item }}"
@@ -67,7 +68,6 @@
         - docker
         - NetworkManager
 
-  post_tasks:
     - name: Enable and start docker service
       service:
         state: started
@@ -81,6 +81,15 @@
         name: NetworkManager
 
 - import_playbook: "{{ openshift_ansible_dir }}/playbooks/prerequisites.yml"
+
+- hosts: all
+  remote_user: root
+  strategy: free
+  tasks:
+    - name: Pre-pull container images
+      shell: docker pull "{{ item }}"
+      with_items: "{{ container_images }}"
+
 - import_playbook: "{{ openshift_ansible_dir | join_paths(openshift_playbook_path | default('playbooks/byo/config.yml')) }}"
 
 - hosts: masters

--- a/playbooks/cluster/openshift/vars/3.9.yml
+++ b/playbooks/cluster/openshift/vars/3.9.yml
@@ -1,2 +1,10 @@
 openshift_image_tag: v3.9.0-alpha.4
 openshift_service_catalog_image_version: "{{ openshift_image_tag }}"
+container_images:
+  - "openshift/origin:{{ openshift_image_tag }}"
+  - "openshift/node:{{ openshift_image_tag }}"
+  - "openshift/openvswitch:{{ openshift_image_tag }}"
+  - "openshift/origin-service-catalog:{{ openshift_image_tag }}"
+  - "ansibleplaybookbundle/origin-ansible-service-broker:latest"
+  - "quay.io/coreos/etcd:latest"
+  - "registry.fedoraproject.org/latest/etcd"

--- a/playbooks/generate-tests.yml
+++ b/playbooks/generate-tests.yml
@@ -1,4 +1,4 @@
 ---
-- hosts: masters[0]
+- hosts: localhost
   roles:
     - role: generate-tests

--- a/roles/generate-tests/tasks/main.yml
+++ b/roles/generate-tests/tasks/main.yml
@@ -1,19 +1,5 @@
 ---
-- name: create remote kubevirt-ansible directory
-  file:
-    path: "{{ kubevirt_dir }}"
-    state: directory
-    mode: 0755
-- name: copy repository to master
-  synchronize:
-    src: "{{ playbook_dir }}/../../kubevirt-ansible"
-    dest: "{{ kubevirt_dir }}"
 - name: generate tests
   make:
-    chdir: "{{ kubevirt_dir }}/kubevirt-ansible"
+    chdir: "{{ playbook_dir }}/.."
     target: generate-tests
-- name: copying tests from master to slave
-  fetch:
-    src: "{{ kubevirt_dir }}/kubevirt-ansible/_out/tests/tests.test"
-    dest: "{{ playbook_dir }}/../_out/tests/"
-    flat: yes


### PR DESCRIPTION
#### Pre pull container images on All VMs
- Pulling the containers in parallel should reduce runtime.

- Also, use Ansible "free" strategy plugin, which allows each host to run
  until the end of the play without waiting for the other hosts.

- Remove pre/post tasks, we don't use it.

#### Generate tests on the localhost
- It will be faster.

- It won't fill the master's root partition.