### PR TITLE
Enable pipelining in ansible.cfg

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -9,6 +9,7 @@ log_path = ./ansible.log
 # Ansible default path is $HOME/.ansible/cp
 # which in jenkins is 105 chars
 control_path = none
+pipelining = True
 ssh_args =
     -o CheckHostIP=no
     -o AddressFamily=inet


### PR DESCRIPTION
Will reduce the number of SSH operations, thus improve
performance.

Signed-off-by: gbenhaim <galbh2@gmail.com>