### PR TITLE
Render a jinja2 template for the kubevirt manifest

### DIFF
--- a/roles/kubevirt/defaults/main.yml
+++ b/roles/kubevirt/defaults/main.yml
@@ -1,10 +1,12 @@
 namespace: "kube-system"
-docker_prefix: "kubevirt"
+registry_url: "docker.io"
+docker_prefix: "{{ registry_url }}/kubevirt"
 cluster: "openshift"
 apb_action: "provision"
 release_manifest_url: "https://github.com/kubevirt/kubevirt/releases/download"
 kubevirt_template_dir: "{{ role_path }}/templates"
 version: 0.5.0
+docker_tag: "v{{ version }}"
 offline_template_dir: "/opt/apb/kubevirt-templates"
 
 default_vm_templates:

--- a/roles/kubevirt/tasks/provision.yml
+++ b/roles/kubevirt/tasks/provision.yml
@@ -25,9 +25,9 @@
   command: "oc adm policy add-scc-to-user hostmount-anyuid -z kubevirt-infra -n {{ namespace }}"
   when: cluster=="openshift"
 
-- name: Check for kubevirt.yaml template in {{ kubevirt_template_dir }}
+- name: Check for kubevirt.yaml.j2 template in {{ kubevirt_template_dir }}
   stat:
-    path: "{{ kubevirt_template_dir }}/kubevirt.yaml"
+    path: "{{ kubevirt_template_dir }}/kubevirt.yaml.j2"
   register: byo_template
 
 - name: Check for offline v{{ version }} templates in {{ offline_template_dir }}
@@ -38,28 +38,21 @@
 
 - name: Download KubeVirt Template
   get_url:
-    url: "{{ release_manifest_url }}/v{{ version }}/kubevirt.yaml"
-    dest: "/tmp/kubevirt.yaml"
+    url: "{{ release_manifest_url }}/v{{ version }}/kubevirt.yaml.j2"
+    dest: "{{ kubevirt_template_dir }}/kubevirt.yaml.j2"
   when: byo_template.stat.exists == False and offline_templates.stat.exists == False
 
 - name: Copy offline templates to /tmp
   copy:
     src: "{{ offline_template_dir }}/v{{ version }}/kubevirt.yaml"
     dest: "/tmp/kubevirt.yaml"
-  when: offline_templates.stat.exists == True
+  when: offline_templates.changed and offline_templates.stat.exists == True
 
 - name: Render KubeVirt Yaml
-  replace:
-    path: "/tmp/kubevirt.yaml"
-    regexp: "namespace: kube-system"
-    replace: "namespace: {{ namespace }}"
-  when: byo_template.stat.exists == False
-
-- name: Render BYO template
   template:
-    src: "{{ kubevirt_template_dir }}/kubevirt.yaml"
-    dest: /tmp/kubevirt.yaml
-  when: byo_template.stat.exists == True
+    src: "kubevirt.yaml.j2"
+    dest: "/tmp/kubevirt.yaml"
+  when: (offline_templates is skipped) or (offline_templates.stat.exists == False)
 
 - name: Create KubeVirt Resources
   command: kubectl apply -f /tmp/kubevirt.yaml

--- a/roles/kubevirt/templates/.gitignore
+++ b/roles/kubevirt/templates/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/roles/kubevirt/templates/kubevirt.yaml.j2
+++ b/roles/kubevirt/templates/kubevirt.yaml.j2
@@ -1,0 +1,2035 @@
+# RBAC
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: kubevirt.io:admin
+  labels:
+    kubevirt.io: ""
+rules:
+  - apiGroups:
+      - subresources.kubevirt.io
+    resources:
+      - virtualmachines/console
+      - virtualmachines/vnc
+    verbs:
+      - get
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - virtualmachines
+      - offlinevirtualmachines
+      - virtualmachinepresets
+      - virtualmachinereplicasets
+    verbs:
+      - get
+      - delete
+      - create
+      - update
+      - patch
+      - list
+      - watch
+      - deletecollection
+  - apiGroups: [""]
+    resources:
+      - configmaps
+    resourceNames:
+      - kubevirt-config
+    verbs:
+      - update
+      - get
+      - patch
+      - create
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: kubevirt.io:edit
+  labels:
+    kubevirt.io: ""
+rules:
+  - apiGroups:
+      - subresources.kubevirt.io
+    resources:
+      - virtualmachines/console
+      - virtualmachines/vnc
+    verbs:
+      - get
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - virtualmachines
+      - offlinevirtualmachines
+      - virtualmachinepresets
+      - virtualmachinereplicasets
+    verbs:
+      - get
+      - delete
+      - create
+      - update
+      - patch
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: kubevirt.io:view
+  labels:
+    kubevirt.io: ""
+rules:
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - virtualmachines
+      - offlinevirtualmachines
+      - virtualmachinepresets
+      - virtualmachinereplicasets
+    verbs:
+      - get
+      - list
+      - watch
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: kubevirt-apiserver
+  namespace: {{ namespace }}
+  labels:
+    kubevirt.io: ""
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kubevirt-apiserver
+  namespace: {{ namespace }}
+  labels:
+    kubevirt.io: ""
+roleRef:
+  kind: ClusterRole
+  name: kubevirt-apiserver
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: kubevirt-apiserver
+    namespace: {{ namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kubevirt-apiserver-auth-delegator
+  namespace: {{ namespace }}
+  labels:
+    kubevirt.io: ""
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: kubevirt-apiserver
+  namespace: {{ namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: kubevirt-apiserver
+  namespace: {{ namespace }}
+  labels:
+    kubevirt.io: ""
+roleRef:
+  kind: Role
+  name: kubevirt-apiserver
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: kubevirt-apiserver
+    namespace: {{ namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: kubevirt-apiserver
+  namespace: {{ namespace }}
+  labels:
+    kubevirt.io: ""
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - delete
+      - update
+      - create
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: kubevirt-apiserver
+  namespace: {{ namespace }}
+  labels:
+    kubevirt.io: ""
+rules:
+  - apiGroups:
+      - apiregistration.k8s.io
+    resources:
+      - apiservices
+    verbs:
+      - get
+      - create
+      - update
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - ''
+    resources:
+      - pods/exec
+    verbs:
+      - create
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - virtualmachines
+    verbs:
+      - get
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: kubevirt-controller
+  namespace: {{ namespace }}
+  labels:
+    kubevirt.io: ""
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+      - update
+      - create
+  - apiGroups:
+      - ''
+    resources:
+      - nodes
+      - persistentvolumeclaims
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - virtualmachines
+      - virtualmachinereplicasets
+      - virtualmachinepresets
+      - offlinevirtualmachines
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+      - update
+      - create
+      - deletecollection
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubevirt-controller
+  namespace: {{ namespace }}
+  labels:
+    kubevirt.io: ""
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubevirt-privileged
+  namespace: {{ namespace }}
+  labels:
+    kubevirt.io: ""
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kubevirt-controller
+  namespace: {{ namespace }}
+  labels:
+    kubevirt.io: ""
+roleRef:
+  kind: ClusterRole
+  name: kubevirt-controller
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: kubevirt-controller
+    namespace: {{ namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kubevirt-controller-cluster-admin
+  namespace: {{ namespace }}
+  labels:
+    kubevirt.io: ""
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: kubevirt-controller
+    namespace: {{ namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kubevirt-privileged-cluster-admin
+  namespace: {{ namespace }}
+  labels:
+    kubevirt.io: ""
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: kubevirt-privileged
+    namespace: {{ namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  labels:
+    kubevirt.io: ""
+    kubernetes.io/bootstrapping: rbac-defaults
+  name: kubevirt.io:default
+rules:
+- apiGroups:
+    - subresources.kubevirt.io
+  resources:
+    - version
+  verbs:
+    - get
+    - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    kubevirt.io: ""
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  name: kubevirt.io:default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubevirt.io:default
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:unauthenticated
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: virt-api
+  namespace: {{ namespace }}
+  labels:
+    kubevirt.io: "virt-api"
+spec:
+  ports:
+    - port: 443
+      targetPort: 8443
+      protocol: TCP
+  selector:
+    kubevirt.io: virt-api
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: virt-api
+  namespace: {{ namespace }}
+  labels:
+    kubevirt.io: "virt-api"
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        kubevirt.io: virt-api
+    spec:
+      serviceAccountName: kubevirt-controller
+      containers:
+        - name: virt-api
+          image: {{ docker_prefix }}/virt-api:{{docker_tag}}
+          imagePullPolicy: IfNotPresent
+          command:
+              - "/virt-api"
+              - "--port"
+              - "8443"
+              - "--subresources-only"
+          ports:
+            - containerPort: 8443
+              name: "virt-api"
+              protocol: "TCP"
+          readinessProbe:
+            tcpSocket:
+              port: 8443
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      securityContext:
+        runAsNonRoot: true
+---
+# kubevirt controller
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: virt-controller
+  namespace: {{ namespace }}
+  labels:
+    kubevirt.io: "virt-controller"
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        kubevirt.io: virt-controller
+    spec:
+      serviceAccountName: kubevirt-controller
+      containers:
+        - name: virt-controller
+          image: {{ docker_prefix }}/virt-controller:{{docker_tag}}
+          imagePullPolicy: IfNotPresent
+          command:
+              - "/virt-controller"
+              - "--launcher-image"
+              - "{{ docker_prefix }}/virt-launcher:{{docker_tag}}"
+              - "--port"
+              - "8182"
+          ports:
+            - containerPort: 8182
+              name: "virt-controller"
+              protocol: "TCP"
+          livenessProbe:
+            failureThreshold: 8
+            httpGet:
+              port: 8182
+              path: /healthz
+            initialDelaySeconds: 15
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              port: 8182
+              path: /leader
+            initialDelaySeconds: 15
+            timeoutSeconds: 10
+          securityContext:
+            runAsNonRoot: true
+---
+# virt-handler daemon set
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: virt-handler
+  namespace: {{ namespace }}
+  labels:
+    kubevirt.io: "virt-handler"
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      name: virt-handler
+      labels:
+        kubevirt.io: virt-handler
+    spec:
+      serviceAccountName: kubevirt-privileged
+      hostPID: true
+      containers:
+        - name: virt-handler
+          ports:
+            - containerPort: 8185
+              hostPort: 8185
+          image: {{ docker_prefix }}/virt-handler:{{docker_tag}}
+          imagePullPolicy: IfNotPresent
+          command:
+            - "/virt-handler"
+            - "-v"
+            - "3"
+            - "--hostname-override"
+            - "$(NODE_NAME)"
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: libvirt-runtime
+              mountPath: /var/run/libvirt
+            - name: virt-share-dir
+              mountPath: /var/run/kubevirt
+            - name: virt-private-dir
+              mountPath: /var/run/kubevirt-private
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+      volumes:
+        - name: libvirt-runtime
+          hostPath:
+            path: /var/run/libvirt
+        - name: virt-share-dir
+          hostPath:
+            path: /var/run/kubevirt
+        - name: virt-private-dir
+          hostPath:
+            path: /var/run/kubevirt-private
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    kubevirt.io: ""
+  name: virtualmachines.kubevirt.io
+spec:
+  group: kubevirt.io
+  names:
+    kind: VirtualMachine
+    plural: virtualmachines
+    shortNames:
+    - vm
+    - vms
+    singular: virtualmachine
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: VirtualMachine is *the* VM Definition. It represents a virtual
+        machine in the runtime environment of kubernetes.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata: {}
+        spec:
+          description: VirtualMachineSpec is a description of a VirtualMachine.
+          properties:
+            affinity:
+              description: Affinity groups all the affinity rules related to a VM
+              properties:
+                nodeAffinity: {}
+            domain:
+              properties:
+                clock:
+                  description: Represents the clock and timers of a vm
+                  properties:
+                    timezone:
+                      description: Timezone sets the guest clock to the specified
+                        timezone. Zone name follows the TZ environment variable format
+                        (e.g. 'America/New_York')
+                      type: string
+                    utc:
+                      description: UTC sets the guest clock to UTC on each boot.
+                      properties:
+                        offsetSeconds:
+                          description: OffsetSeconds specifies an offset in seconds,
+                            relative to UTC. If set, guest changes to the clock will
+                            be kept during reboots and not reset.
+                          format: int32
+                          type: integer
+                cpu:
+                  description: CPU allow specifying the CPU topology
+                  properties:
+                    cores:
+                      description: Cores specifies the number of cores inside the
+                        vm. Must be a value greater or equal 1.
+                      format: int64
+                      type: integer
+                devices:
+                  properties:
+                    disks:
+                      description: Disks describes disks, cdroms, floppy and luns
+                        which are connected to the vm
+                      items:
+                        properties:
+                          bootOrder:
+                            description: BootOrder is an integer value > 0, used to
+                              determine ordering of boot devices. Lower values take
+                              precedence. Disks without a boot order are not tried
+                              if a disk with a boot order exists.
+                            format: int32
+                            type: integer
+                          cdrom:
+                            properties:
+                              bus:
+                                description: 'Bus indicates the type of disk device
+                                  to emulate. supported values: virtio, sata, scsi,
+                                  ide'
+                                type: string
+                              readonly:
+                                description: ReadOnly Defaults to true
+                                type: boolean
+                              tray:
+                                description: Tray indicates if the tray of the device
+                                  is open or closed. Allowed values are "open" and
+                                  "closed" Defaults to closed
+                                type: string
+                          disk:
+                            properties:
+                              bus:
+                                description: 'Bus indicates the type of disk device
+                                  to emulate. supported values: virtio, sata, scsi,
+                                  ide'
+                                type: string
+                              readonly:
+                                description: ReadOnly Defaults to false
+                                type: boolean
+                          floppy:
+                            properties:
+                              readonly:
+                                description: ReadOnly Defaults to false
+                                type: boolean
+                              tray:
+                                description: Tray indicates if the tray of the device
+                                  is open or closed. Allowed values are "open" and
+                                  "closed" Defaults to closed
+                                type: string
+                          lun:
+                            properties:
+                              bus:
+                                description: 'Bus indicates the type of disk device
+                                  to emulate. supported values: virtio, sata, scsi,
+                                  ide'
+                                type: string
+                              readonly:
+                                description: ReadOnly Defaults to false
+                                type: boolean
+                          name:
+                            description: Name is the device name
+                            type: string
+                          volumeName:
+                            description: Name of the volume which is referenced Must
+                              match the Name of a Volume.
+                            type: string
+                        required:
+                        - name
+                        - volumeName
+                      type: array
+                    watchdog:
+                      description: Named watchdog device
+                      properties:
+                        i6300esb:
+                          description: i6300esb watchdog device
+                          properties:
+                            action:
+                              description: The action to take. Valid values are poweroff,
+                                reset, shutdown. Defaults to reset
+                              type: string
+                        name:
+                          description: Name of the watchdog
+                          type: string
+                      required:
+                      - name
+                features:
+                  properties:
+                    acpi:
+                      description: Represents if a feature is enabled or disabled
+                      properties:
+                        enabled:
+                          description: Enabled determines if the feature should be
+                            enabled or disabled on the guest Defaults to true
+                          type: boolean
+                    apic:
+                      properties:
+                        enabled:
+                          description: Enabled determines if the feature should be
+                            enabled or disabled on the guest Defaults to true
+                          type: boolean
+                        endOfInterrupt:
+                          description: EndOfInterrupt enables the end of interrupt
+                            notification in the guest Defaults to false
+                          type: boolean
+                    hyperv:
+                      description: Hyperv specific features
+                      properties:
+                        relaxed:
+                          description: Represents if a feature is enabled or disabled
+                          properties:
+                            enabled:
+                              description: Enabled determines if the feature should
+                                be enabled or disabled on the guest Defaults to true
+                              type: boolean
+                        reset:
+                          description: Represents if a feature is enabled or disabled
+                          properties:
+                            enabled:
+                              description: Enabled determines if the feature should
+                                be enabled or disabled on the guest Defaults to true
+                              type: boolean
+                        runtime:
+                          description: Represents if a feature is enabled or disabled
+                          properties:
+                            enabled:
+                              description: Enabled determines if the feature should
+                                be enabled or disabled on the guest Defaults to true
+                              type: boolean
+                        spinlocks:
+                          properties:
+                            enabled:
+                              description: Enabled determines if the feature should
+                                be enabled or disabled on the guest Defaults to true
+                              type: boolean
+                            spinlocks:
+                              description: Retries indicates the number of retries
+                                Must be a value greater or equal 4096 Defaults to
+                                4096
+                              format: int64
+                              type: integer
+                        synic:
+                          description: Represents if a feature is enabled or disabled
+                          properties:
+                            enabled:
+                              description: Enabled determines if the feature should
+                                be enabled or disabled on the guest Defaults to true
+                              type: boolean
+                        synictimer:
+                          description: Represents if a feature is enabled or disabled
+                          properties:
+                            enabled:
+                              description: Enabled determines if the feature should
+                                be enabled or disabled on the guest Defaults to true
+                              type: boolean
+                        vapic:
+                          description: Represents if a feature is enabled or disabled
+                          properties:
+                            enabled:
+                              description: Enabled determines if the feature should
+                                be enabled or disabled on the guest Defaults to true
+                              type: boolean
+                        vendorid:
+                          properties:
+                            enabled:
+                              description: Enabled determines if the feature should
+                                be enabled or disabled on the guest Defaults to true
+                              type: boolean
+                            vendorid:
+                              description: VendorID sets the hypervisor vendor id,
+                                visible to the vm String up to twelve characters
+                              type: string
+                        vpindex:
+                          description: Represents if a feature is enabled or disabled
+                          properties:
+                            enabled:
+                              description: Enabled determines if the feature should
+                                be enabled or disabled on the guest Defaults to true
+                              type: boolean
+                firmware:
+                  properties:
+                    uuid:
+                      description: UUID reported by the vm bios Defaults to a random
+                        generated uid
+                      type: string
+                machine:
+                  properties:
+                    type:
+                      description: QEMU machine type is the actual chipset of the
+                        VM.
+                      type: string
+                  required:
+                  - type
+                resources:
+                  properties:
+                    limits:
+                      description: Limits describes the maximum amount of compute
+                        resources allowed. Valid resource keys are "memory" and "cpu".
+                      type: object
+                    requests:
+                      description: Requests is a description of the initial vm resources.
+                        Valid resource keys are "memory" and "cpu".
+                      type: object
+              required:
+              - devices
+            hostname:
+              description: Specifies the hostname of the vm If not specified, the
+                hostname will be set to the name of the vm, if dhcp or cloud-init
+                is configured properly.
+              type: string
+            nodeSelector:
+              description: 'NodeSelector is a selector which must be true for the
+                vm to fit on a node. Selector which must match a node''s labels for
+                the vm to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+              type: object
+            subdomain:
+              description: If specified, the fully qualified vm hostname will be "<hostname>.<subdomain>.<pod
+                namespace>.svc.<cluster domain>". If not specified, the vm will not
+                have a domainname at all. The DNS entry will resolve to the vm, no
+                matter if the vm itself can pick up a hostname.
+              type: string
+            terminationGracePeriodSeconds:
+              description: Grace period observed after signalling a VM to stop after
+                which the VM is force terminated.
+              format: int64
+              type: integer
+            volumes:
+              description: List of volumes that can be mounted by disks belonging
+                to the vm.
+              items:
+                description: Volume represents a named volume in a vm.
+                properties:
+                  cloudInitNoCloud:
+                    description: 'Represents a cloud-init nocloud user data source
+                      More info: http://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html'
+                    properties:
+                      secretRef: {}
+                      userData:
+                        description: UserData contains NoCloud inline cloud-init userdata
+                        type: string
+                      userDataBase64:
+                        description: UserDataBase64 contains NoCloud cloud-init userdata
+                          as a base64 encoded string
+                        type: string
+                  emptyDisk:
+                    description: EmptyDisk represents a temporary disk which shares
+                      the vms lifecycle
+                    properties:
+                      capacity: {}
+                    required:
+                    - capacity
+                  ephemeral:
+                    properties:
+                      persistentVolumeClaim: {}
+                  name:
+                    description: 'Volume''s name. Must be a DNS_LABEL and unique within
+                      the vm. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  persistentVolumeClaim: {}
+                  registryDisk:
+                    description: Represents a docker image with an embedded disk
+                    properties:
+                      image:
+                        description: Image is the name of the image with the embedded
+                          disk
+                        type: string
+                      imagePullSecret:
+                        description: ImagePullSecret is the name of the Docker registry
+                          secret required to pull the image. The secret must already
+                          exist.
+                        type: string
+                    required:
+                    - image
+                required:
+                - name
+              type: array
+          required:
+          - domain
+        status:
+          description: VirtualMachineStatus represents information about the status
+            of a VM. Status may trail the actual state of a system.
+          properties:
+            conditions:
+              description: Conditions are specific points in VM's pod runtime.
+              items:
+                properties:
+                  lastProbeTime: {}
+                  lastTransitionTime: {}
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+              type: array
+            interfaces:
+              description: Interfaces represent the details of available network interfaces.
+              items:
+                properties:
+                  ipAddress:
+                    description: IP address of a Virtual Machine interface
+                    type: string
+                  mac:
+                    description: Hardware address of a Virtual Machine interface
+                    type: string
+              type: array
+            nodeName:
+              description: NodeName is the name where the VM is currently running.
+              type: string
+            phase:
+              description: Phase is the status of the VM in kubernetes world. It is
+                not the VM status, but partially correlates to it.
+              type: string
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    kubevirt.io: ""
+  name: virtualmachinereplicasets.kubevirt.io
+spec:
+  group: kubevirt.io
+  names:
+    kind: VirtualMachineReplicaSet
+    plural: virtualmachinereplicasets
+    shortNames:
+    - vmrs
+    - vmrss
+    singular: virtualmachinereplicaset
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: VM is *the* VM Definition. It represents a virtual machine in the
+        runtime environment of kubernetes.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata: {}
+        spec:
+          properties:
+            paused:
+              description: Indicates that the replica set is paused.
+              type: boolean
+            replicas:
+              description: Number of desired pods. This is a pointer to distinguish
+                between explicit zero and not specified. Defaults to 1.
+              format: int32
+              type: integer
+            selector: {}
+            template:
+              properties:
+                metadata: {}
+                spec:
+                  description: VirtualMachineSpec is a description of a VirtualMachine.
+                  properties:
+                    affinity:
+                      description: Affinity groups all the affinity rules related
+                        to a VM
+                      properties:
+                        nodeAffinity: {}
+                    domain:
+                      properties:
+                        clock:
+                          description: Represents the clock and timers of a vm
+                          properties:
+                            timezone:
+                              description: Timezone sets the guest clock to the specified
+                                timezone. Zone name follows the TZ environment variable
+                                format (e.g. 'America/New_York')
+                              type: string
+                            utc:
+                              description: UTC sets the guest clock to UTC on each
+                                boot.
+                              properties:
+                                offsetSeconds:
+                                  description: OffsetSeconds specifies an offset in
+                                    seconds, relative to UTC. If set, guest changes
+                                    to the clock will be kept during reboots and not
+                                    reset.
+                                  format: int32
+                                  type: integer
+                        cpu:
+                          description: CPU allow specifying the CPU topology
+                          properties:
+                            cores:
+                              description: Cores specifies the number of cores inside
+                                the vm. Must be a value greater or equal 1.
+                              format: int64
+                              type: integer
+                        devices:
+                          properties:
+                            disks:
+                              description: Disks describes disks, cdroms, floppy and
+                                luns which are connected to the vm
+                              items:
+                                properties:
+                                  bootOrder:
+                                    description: BootOrder is an integer value > 0,
+                                      used to determine ordering of boot devices.
+                                      Lower values take precedence. Disks without
+                                      a boot order are not tried if a disk with a
+                                      boot order exists.
+                                    format: int32
+                                    type: integer
+                                  cdrom:
+                                    properties:
+                                      bus:
+                                        description: 'Bus indicates the type of disk
+                                          device to emulate. supported values: virtio,
+                                          sata, scsi, ide'
+                                        type: string
+                                      readonly:
+                                        description: ReadOnly Defaults to true
+                                        type: boolean
+                                      tray:
+                                        description: Tray indicates if the tray of
+                                          the device is open or closed. Allowed values
+                                          are "open" and "closed" Defaults to closed
+                                        type: string
+                                  disk:
+                                    properties:
+                                      bus:
+                                        description: 'Bus indicates the type of disk
+                                          device to emulate. supported values: virtio,
+                                          sata, scsi, ide'
+                                        type: string
+                                      readonly:
+                                        description: ReadOnly Defaults to false
+                                        type: boolean
+                                  floppy:
+                                    properties:
+                                      readonly:
+                                        description: ReadOnly Defaults to false
+                                        type: boolean
+                                      tray:
+                                        description: Tray indicates if the tray of
+                                          the device is open or closed. Allowed values
+                                          are "open" and "closed" Defaults to closed
+                                        type: string
+                                  lun:
+                                    properties:
+                                      bus:
+                                        description: 'Bus indicates the type of disk
+                                          device to emulate. supported values: virtio,
+                                          sata, scsi, ide'
+                                        type: string
+                                      readonly:
+                                        description: ReadOnly Defaults to false
+                                        type: boolean
+                                  name:
+                                    description: Name is the device name
+                                    type: string
+                                  volumeName:
+                                    description: Name of the volume which is referenced
+                                      Must match the Name of a Volume.
+                                    type: string
+                                required:
+                                - name
+                                - volumeName
+                              type: array
+                            watchdog:
+                              description: Named watchdog device
+                              properties:
+                                i6300esb:
+                                  description: i6300esb watchdog device
+                                  properties:
+                                    action:
+                                      description: The action to take. Valid values
+                                        are poweroff, reset, shutdown. Defaults to
+                                        reset
+                                      type: string
+                                name:
+                                  description: Name of the watchdog
+                                  type: string
+                              required:
+                              - name
+                        features:
+                          properties:
+                            acpi:
+                              description: Represents if a feature is enabled or disabled
+                              properties:
+                                enabled:
+                                  description: Enabled determines if the feature should
+                                    be enabled or disabled on the guest Defaults to
+                                    true
+                                  type: boolean
+                            apic:
+                              properties:
+                                enabled:
+                                  description: Enabled determines if the feature should
+                                    be enabled or disabled on the guest Defaults to
+                                    true
+                                  type: boolean
+                                endOfInterrupt:
+                                  description: EndOfInterrupt enables the end of interrupt
+                                    notification in the guest Defaults to false
+                                  type: boolean
+                            hyperv:
+                              description: Hyperv specific features
+                              properties:
+                                relaxed:
+                                  description: Represents if a feature is enabled
+                                    or disabled
+                                  properties:
+                                    enabled:
+                                      description: Enabled determines if the feature
+                                        should be enabled or disabled on the guest
+                                        Defaults to true
+                                      type: boolean
+                                reset:
+                                  description: Represents if a feature is enabled
+                                    or disabled
+                                  properties:
+                                    enabled:
+                                      description: Enabled determines if the feature
+                                        should be enabled or disabled on the guest
+                                        Defaults to true
+                                      type: boolean
+                                runtime:
+                                  description: Represents if a feature is enabled
+                                    or disabled
+                                  properties:
+                                    enabled:
+                                      description: Enabled determines if the feature
+                                        should be enabled or disabled on the guest
+                                        Defaults to true
+                                      type: boolean
+                                spinlocks:
+                                  properties:
+                                    enabled:
+                                      description: Enabled determines if the feature
+                                        should be enabled or disabled on the guest
+                                        Defaults to true
+                                      type: boolean
+                                    spinlocks:
+                                      description: Retries indicates the number of
+                                        retries Must be a value greater or equal 4096
+                                        Defaults to 4096
+                                      format: int64
+                                      type: integer
+                                synic:
+                                  description: Represents if a feature is enabled
+                                    or disabled
+                                  properties:
+                                    enabled:
+                                      description: Enabled determines if the feature
+                                        should be enabled or disabled on the guest
+                                        Defaults to true
+                                      type: boolean
+                                synictimer:
+                                  description: Represents if a feature is enabled
+                                    or disabled
+                                  properties:
+                                    enabled:
+                                      description: Enabled determines if the feature
+                                        should be enabled or disabled on the guest
+                                        Defaults to true
+                                      type: boolean
+                                vapic:
+                                  description: Represents if a feature is enabled
+                                    or disabled
+                                  properties:
+                                    enabled:
+                                      description: Enabled determines if the feature
+                                        should be enabled or disabled on the guest
+                                        Defaults to true
+                                      type: boolean
+                                vendorid:
+                                  properties:
+                                    enabled:
+                                      description: Enabled determines if the feature
+                                        should be enabled or disabled on the guest
+                                        Defaults to true
+                                      type: boolean
+                                    vendorid:
+                                      description: VendorID sets the hypervisor vendor
+                                        id, visible to the vm String up to twelve
+                                        characters
+                                      type: string
+                                vpindex:
+                                  description: Represents if a feature is enabled
+                                    or disabled
+                                  properties:
+                                    enabled:
+                                      description: Enabled determines if the feature
+                                        should be enabled or disabled on the guest
+                                        Defaults to true
+                                      type: boolean
+                        firmware:
+                          properties:
+                            uuid:
+                              description: UUID reported by the vm bios Defaults to
+                                a random generated uid
+                              type: string
+                        machine:
+                          properties:
+                            type:
+                              description: QEMU machine type is the actual chipset
+                                of the VM.
+                              type: string
+                          required:
+                          - type
+                        resources:
+                          properties:
+                            limits:
+                              description: Limits describes the maximum amount of
+                                compute resources allowed. Valid resource keys are
+                                "memory" and "cpu".
+                              type: object
+                            requests:
+                              description: Requests is a description of the initial
+                                vm resources. Valid resource keys are "memory" and
+                                "cpu".
+                              type: object
+                      required:
+                      - devices
+                    hostname:
+                      description: Specifies the hostname of the vm If not specified,
+                        the hostname will be set to the name of the vm, if dhcp or
+                        cloud-init is configured properly.
+                      type: string
+                    nodeSelector:
+                      description: 'NodeSelector is a selector which must be true
+                        for the vm to fit on a node. Selector which must match a node''s
+                        labels for the vm to be scheduled on that node. More info:
+                        https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                      type: object
+                    subdomain:
+                      description: If specified, the fully qualified vm hostname will
+                        be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
+                        If not specified, the vm will not have a domainname at all.
+                        The DNS entry will resolve to the vm, no matter if the vm
+                        itself can pick up a hostname.
+                      type: string
+                    terminationGracePeriodSeconds:
+                      description: Grace period observed after signalling a VM to
+                        stop after which the VM is force terminated.
+                      format: int64
+                      type: integer
+                    volumes:
+                      description: List of volumes that can be mounted by disks belonging
+                        to the vm.
+                      items:
+                        description: Volume represents a named volume in a vm.
+                        properties:
+                          cloudInitNoCloud:
+                            description: 'Represents a cloud-init nocloud user data
+                              source More info: http://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html'
+                            properties:
+                              secretRef: {}
+                              userData:
+                                description: UserData contains NoCloud inline cloud-init
+                                  userdata
+                                type: string
+                              userDataBase64:
+                                description: UserDataBase64 contains NoCloud cloud-init
+                                  userdata as a base64 encoded string
+                                type: string
+                          emptyDisk:
+                            description: EmptyDisk represents a temporary disk which
+                              shares the vms lifecycle
+                            properties:
+                              capacity: {}
+                            required:
+                            - capacity
+                          ephemeral:
+                            properties:
+                              persistentVolumeClaim: {}
+                          name:
+                            description: 'Volume''s name. Must be a DNS_LABEL and
+                              unique within the vm. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          persistentVolumeClaim: {}
+                          registryDisk:
+                            description: Represents a docker image with an embedded
+                              disk
+                            properties:
+                              image:
+                                description: Image is the name of the image with the
+                                  embedded disk
+                                type: string
+                              imagePullSecret:
+                                description: ImagePullSecret is the name of the Docker
+                                  registry secret required to pull the image. The
+                                  secret must already exist.
+                                type: string
+                            required:
+                            - image
+                        required:
+                        - name
+                      type: array
+                  required:
+                  - domain
+          required:
+          - selector
+          - template
+        status:
+          properties:
+            conditions:
+              items:
+                properties:
+                  lastProbeTime: {}
+                  lastTransitionTime: {}
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+              type: array
+            readyReplicas:
+              description: The number of ready replicas for this replica set.
+              format: int32
+              type: integer
+            replicas:
+              description: Total number of non-terminated pods targeted by this deployment
+                (their labels match the selector).
+              format: int32
+              type: integer
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    kubevirt.io: ""
+  name: virtualmachinepresets.kubevirt.io
+spec:
+  group: kubevirt.io
+  names:
+    kind: VirtualMachinePreset
+    plural: virtualmachinepresets
+    shortNames:
+    - vmpreset
+    - vmpresets
+    singular: virtualmachinepreset
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata: {}
+        spec:
+          properties:
+            domain:
+              properties:
+                clock:
+                  description: Represents the clock and timers of a vm
+                  properties:
+                    timezone:
+                      description: Timezone sets the guest clock to the specified
+                        timezone. Zone name follows the TZ environment variable format
+                        (e.g. 'America/New_York')
+                      type: string
+                    utc:
+                      description: UTC sets the guest clock to UTC on each boot.
+                      properties:
+                        offsetSeconds:
+                          description: OffsetSeconds specifies an offset in seconds,
+                            relative to UTC. If set, guest changes to the clock will
+                            be kept during reboots and not reset.
+                          format: int32
+                          type: integer
+                cpu:
+                  description: CPU allow specifying the CPU topology
+                  properties:
+                    cores:
+                      description: Cores specifies the number of cores inside the
+                        vm. Must be a value greater or equal 1.
+                      format: int64
+                      type: integer
+                devices:
+                  properties:
+                    disks:
+                      description: Disks describes disks, cdroms, floppy and luns
+                        which are connected to the vm
+                      items:
+                        properties:
+                          bootOrder:
+                            description: BootOrder is an integer value > 0, used to
+                              determine ordering of boot devices. Lower values take
+                              precedence. Disks without a boot order are not tried
+                              if a disk with a boot order exists.
+                            format: int32
+                            type: integer
+                          cdrom:
+                            properties:
+                              bus:
+                                description: 'Bus indicates the type of disk device
+                                  to emulate. supported values: virtio, sata, scsi,
+                                  ide'
+                                type: string
+                              readonly:
+                                description: ReadOnly Defaults to true
+                                type: boolean
+                              tray:
+                                description: Tray indicates if the tray of the device
+                                  is open or closed. Allowed values are "open" and
+                                  "closed" Defaults to closed
+                                type: string
+                          disk:
+                            properties:
+                              bus:
+                                description: 'Bus indicates the type of disk device
+                                  to emulate. supported values: virtio, sata, scsi,
+                                  ide'
+                                type: string
+                              readonly:
+                                description: ReadOnly Defaults to false
+                                type: boolean
+                          floppy:
+                            properties:
+                              readonly:
+                                description: ReadOnly Defaults to false
+                                type: boolean
+                              tray:
+                                description: Tray indicates if the tray of the device
+                                  is open or closed. Allowed values are "open" and
+                                  "closed" Defaults to closed
+                                type: string
+                          lun:
+                            properties:
+                              bus:
+                                description: 'Bus indicates the type of disk device
+                                  to emulate. supported values: virtio, sata, scsi,
+                                  ide'
+                                type: string
+                              readonly:
+                                description: ReadOnly Defaults to false
+                                type: boolean
+                          name:
+                            description: Name is the device name
+                            type: string
+                          volumeName:
+                            description: Name of the volume which is referenced Must
+                              match the Name of a Volume.
+                            type: string
+                        required:
+                        - name
+                        - volumeName
+                      type: array
+                    watchdog:
+                      description: Named watchdog device
+                      properties:
+                        i6300esb:
+                          description: i6300esb watchdog device
+                          properties:
+                            action:
+                              description: The action to take. Valid values are poweroff,
+                                reset, shutdown. Defaults to reset
+                              type: string
+                        name:
+                          description: Name of the watchdog
+                          type: string
+                      required:
+                      - name
+                features:
+                  properties:
+                    acpi:
+                      description: Represents if a feature is enabled or disabled
+                      properties:
+                        enabled:
+                          description: Enabled determines if the feature should be
+                            enabled or disabled on the guest Defaults to true
+                          type: boolean
+                    apic:
+                      properties:
+                        enabled:
+                          description: Enabled determines if the feature should be
+                            enabled or disabled on the guest Defaults to true
+                          type: boolean
+                        endOfInterrupt:
+                          description: EndOfInterrupt enables the end of interrupt
+                            notification in the guest Defaults to false
+                          type: boolean
+                    hyperv:
+                      description: Hyperv specific features
+                      properties:
+                        relaxed:
+                          description: Represents if a feature is enabled or disabled
+                          properties:
+                            enabled:
+                              description: Enabled determines if the feature should
+                                be enabled or disabled on the guest Defaults to true
+                              type: boolean
+                        reset:
+                          description: Represents if a feature is enabled or disabled
+                          properties:
+                            enabled:
+                              description: Enabled determines if the feature should
+                                be enabled or disabled on the guest Defaults to true
+                              type: boolean
+                        runtime:
+                          description: Represents if a feature is enabled or disabled
+                          properties:
+                            enabled:
+                              description: Enabled determines if the feature should
+                                be enabled or disabled on the guest Defaults to true
+                              type: boolean
+                        spinlocks:
+                          properties:
+                            enabled:
+                              description: Enabled determines if the feature should
+                                be enabled or disabled on the guest Defaults to true
+                              type: boolean
+                            spinlocks:
+                              description: Retries indicates the number of retries
+                                Must be a value greater or equal 4096 Defaults to
+                                4096
+                              format: int64
+                              type: integer
+                        synic:
+                          description: Represents if a feature is enabled or disabled
+                          properties:
+                            enabled:
+                              description: Enabled determines if the feature should
+                                be enabled or disabled on the guest Defaults to true
+                              type: boolean
+                        synictimer:
+                          description: Represents if a feature is enabled or disabled
+                          properties:
+                            enabled:
+                              description: Enabled determines if the feature should
+                                be enabled or disabled on the guest Defaults to true
+                              type: boolean
+                        vapic:
+                          description: Represents if a feature is enabled or disabled
+                          properties:
+                            enabled:
+                              description: Enabled determines if the feature should
+                                be enabled or disabled on the guest Defaults to true
+                              type: boolean
+                        vendorid:
+                          properties:
+                            enabled:
+                              description: Enabled determines if the feature should
+                                be enabled or disabled on the guest Defaults to true
+                              type: boolean
+                            vendorid:
+                              description: VendorID sets the hypervisor vendor id,
+                                visible to the vm String up to twelve characters
+                              type: string
+                        vpindex:
+                          description: Represents if a feature is enabled or disabled
+                          properties:
+                            enabled:
+                              description: Enabled determines if the feature should
+                                be enabled or disabled on the guest Defaults to true
+                              type: boolean
+                firmware:
+                  properties:
+                    uuid:
+                      description: UUID reported by the vm bios Defaults to a random
+                        generated uid
+                      type: string
+                machine:
+                  properties:
+                    type:
+                      description: QEMU machine type is the actual chipset of the
+                        VM.
+                      type: string
+                  required:
+                  - type
+                resources:
+                  properties:
+                    limits:
+                      description: Limits describes the maximum amount of compute
+                        resources allowed. Valid resource keys are "memory" and "cpu".
+                      type: object
+                    requests:
+                      description: Requests is a description of the initial vm resources.
+                        Valid resource keys are "memory" and "cpu".
+                      type: object
+              required:
+              - devices
+            selector: {}
+          required:
+          - selector
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    kubevirt.io: ""
+  name: offlinevirtualmachines.kubevirt.io
+spec:
+  group: kubevirt.io
+  names:
+    kind: OfflineVirtualMachine
+    plural: offlinevirtualmachines
+    shortNames:
+    - ovm
+    - ovms
+    singular: offlinevirtualmachine
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: OfflineVirtualMachine handles the VirtualMachines that are not
+        running or are in a stopped state The OfflineVirtualMachine contains the template
+        to create the VirtualMachine. It also mirrors the running state of the created
+        VirtualMachine in its status.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata: {}
+        spec:
+          description: OfflineVirtualMachineSpec describes how the proper OfflineVirtualMachine
+            should look like
+          properties:
+            running:
+              description: Running controls whether the associatied VirtualMachine
+                is created or not
+              type: boolean
+            template:
+              properties:
+                metadata: {}
+                spec:
+                  description: VirtualMachineSpec is a description of a VirtualMachine.
+                  properties:
+                    affinity:
+                      description: Affinity groups all the affinity rules related
+                        to a VM
+                      properties:
+                        nodeAffinity: {}
+                    domain:
+                      properties:
+                        clock:
+                          description: Represents the clock and timers of a vm
+                          properties:
+                            timezone:
+                              description: Timezone sets the guest clock to the specified
+                                timezone. Zone name follows the TZ environment variable
+                                format (e.g. 'America/New_York')
+                              type: string
+                            utc:
+                              description: UTC sets the guest clock to UTC on each
+                                boot.
+                              properties:
+                                offsetSeconds:
+                                  description: OffsetSeconds specifies an offset in
+                                    seconds, relative to UTC. If set, guest changes
+                                    to the clock will be kept during reboots and not
+                                    reset.
+                                  format: int32
+                                  type: integer
+                        cpu:
+                          description: CPU allow specifying the CPU topology
+                          properties:
+                            cores:
+                              description: Cores specifies the number of cores inside
+                                the vm. Must be a value greater or equal 1.
+                              format: int64
+                              type: integer
+                        devices:
+                          properties:
+                            disks:
+                              description: Disks describes disks, cdroms, floppy and
+                                luns which are connected to the vm
+                              items:
+                                properties:
+                                  bootOrder:
+                                    description: BootOrder is an integer value > 0,
+                                      used to determine ordering of boot devices.
+                                      Lower values take precedence. Disks without
+                                      a boot order are not tried if a disk with a
+                                      boot order exists.
+                                    format: int32
+                                    type: integer
+                                  cdrom:
+                                    properties:
+                                      bus:
+                                        description: 'Bus indicates the type of disk
+                                          device to emulate. supported values: virtio,
+                                          sata, scsi, ide'
+                                        type: string
+                                      readonly:
+                                        description: ReadOnly Defaults to true
+                                        type: boolean
+                                      tray:
+                                        description: Tray indicates if the tray of
+                                          the device is open or closed. Allowed values
+                                          are "open" and "closed" Defaults to closed
+                                        type: string
+                                  disk:
+                                    properties:
+                                      bus:
+                                        description: 'Bus indicates the type of disk
+                                          device to emulate. supported values: virtio,
+                                          sata, scsi, ide'
+                                        type: string
+                                      readonly:
+                                        description: ReadOnly Defaults to false
+                                        type: boolean
+                                  floppy:
+                                    properties:
+                                      readonly:
+                                        description: ReadOnly Defaults to false
+                                        type: boolean
+                                      tray:
+                                        description: Tray indicates if the tray of
+                                          the device is open or closed. Allowed values
+                                          are "open" and "closed" Defaults to closed
+                                        type: string
+                                  lun:
+                                    properties:
+                                      bus:
+                                        description: 'Bus indicates the type of disk
+                                          device to emulate. supported values: virtio,
+                                          sata, scsi, ide'
+                                        type: string
+                                      readonly:
+                                        description: ReadOnly Defaults to false
+                                        type: boolean
+                                  name:
+                                    description: Name is the device name
+                                    type: string
+                                  volumeName:
+                                    description: Name of the volume which is referenced
+                                      Must match the Name of a Volume.
+                                    type: string
+                                required:
+                                - name
+                                - volumeName
+                              type: array
+                            watchdog:
+                              description: Named watchdog device
+                              properties:
+                                i6300esb:
+                                  description: i6300esb watchdog device
+                                  properties:
+                                    action:
+                                      description: The action to take. Valid values
+                                        are poweroff, reset, shutdown. Defaults to
+                                        reset
+                                      type: string
+                                name:
+                                  description: Name of the watchdog
+                                  type: string
+                              required:
+                              - name
+                        features:
+                          properties:
+                            acpi:
+                              description: Represents if a feature is enabled or disabled
+                              properties:
+                                enabled:
+                                  description: Enabled determines if the feature should
+                                    be enabled or disabled on the guest Defaults to
+                                    true
+                                  type: boolean
+                            apic:
+                              properties:
+                                enabled:
+                                  description: Enabled determines if the feature should
+                                    be enabled or disabled on the guest Defaults to
+                                    true
+                                  type: boolean
+                                endOfInterrupt:
+                                  description: EndOfInterrupt enables the end of interrupt
+                                    notification in the guest Defaults to false
+                                  type: boolean
+                            hyperv:
+                              description: Hyperv specific features
+                              properties:
+                                relaxed:
+                                  description: Represents if a feature is enabled
+                                    or disabled
+                                  properties:
+                                    enabled:
+                                      description: Enabled determines if the feature
+                                        should be enabled or disabled on the guest
+                                        Defaults to true
+                                      type: boolean
+                                reset:
+                                  description: Represents if a feature is enabled
+                                    or disabled
+                                  properties:
+                                    enabled:
+                                      description: Enabled determines if the feature
+                                        should be enabled or disabled on the guest
+                                        Defaults to true
+                                      type: boolean
+                                runtime:
+                                  description: Represents if a feature is enabled
+                                    or disabled
+                                  properties:
+                                    enabled:
+                                      description: Enabled determines if the feature
+                                        should be enabled or disabled on the guest
+                                        Defaults to true
+                                      type: boolean
+                                spinlocks:
+                                  properties:
+                                    enabled:
+                                      description: Enabled determines if the feature
+                                        should be enabled or disabled on the guest
+                                        Defaults to true
+                                      type: boolean
+                                    spinlocks:
+                                      description: Retries indicates the number of
+                                        retries Must be a value greater or equal 4096
+                                        Defaults to 4096
+                                      format: int64
+                                      type: integer
+                                synic:
+                                  description: Represents if a feature is enabled
+                                    or disabled
+                                  properties:
+                                    enabled:
+                                      description: Enabled determines if the feature
+                                        should be enabled or disabled on the guest
+                                        Defaults to true
+                                      type: boolean
+                                synictimer:
+                                  description: Represents if a feature is enabled
+                                    or disabled
+                                  properties:
+                                    enabled:
+                                      description: Enabled determines if the feature
+                                        should be enabled or disabled on the guest
+                                        Defaults to true
+                                      type: boolean
+                                vapic:
+                                  description: Represents if a feature is enabled
+                                    or disabled
+                                  properties:
+                                    enabled:
+                                      description: Enabled determines if the feature
+                                        should be enabled or disabled on the guest
+                                        Defaults to true
+                                      type: boolean
+                                vendorid:
+                                  properties:
+                                    enabled:
+                                      description: Enabled determines if the feature
+                                        should be enabled or disabled on the guest
+                                        Defaults to true
+                                      type: boolean
+                                    vendorid:
+                                      description: VendorID sets the hypervisor vendor
+                                        id, visible to the vm String up to twelve
+                                        characters
+                                      type: string
+                                vpindex:
+                                  description: Represents if a feature is enabled
+                                    or disabled
+                                  properties:
+                                    enabled:
+                                      description: Enabled determines if the feature
+                                        should be enabled or disabled on the guest
+                                        Defaults to true
+                                      type: boolean
+                        firmware:
+                          properties:
+                            uuid:
+                              description: UUID reported by the vm bios Defaults to
+                                a random generated uid
+                              type: string
+                        machine:
+                          properties:
+                            type:
+                              description: QEMU machine type is the actual chipset
+                                of the VM.
+                              type: string
+                          required:
+                          - type
+                        resources:
+                          properties:
+                            limits:
+                              description: Limits describes the maximum amount of
+                                compute resources allowed. Valid resource keys are
+                                "memory" and "cpu".
+                              type: object
+                            requests:
+                              description: Requests is a description of the initial
+                                vm resources. Valid resource keys are "memory" and
+                                "cpu".
+                              type: object
+                      required:
+                      - devices
+                    hostname:
+                      description: Specifies the hostname of the vm If not specified,
+                        the hostname will be set to the name of the vm, if dhcp or
+                        cloud-init is configured properly.
+                      type: string
+                    nodeSelector:
+                      description: 'NodeSelector is a selector which must be true
+                        for the vm to fit on a node. Selector which must match a node''s
+                        labels for the vm to be scheduled on that node. More info:
+                        https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                      type: object
+                    subdomain:
+                      description: If specified, the fully qualified vm hostname will
+                        be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
+                        If not specified, the vm will not have a domainname at all.
+                        The DNS entry will resolve to the vm, no matter if the vm
+                        itself can pick up a hostname.
+                      type: string
+                    terminationGracePeriodSeconds:
+                      description: Grace period observed after signalling a VM to
+                        stop after which the VM is force terminated.
+                      format: int64
+                      type: integer
+                    volumes:
+                      description: List of volumes that can be mounted by disks belonging
+                        to the vm.
+                      items:
+                        description: Volume represents a named volume in a vm.
+                        properties:
+                          cloudInitNoCloud:
+                            description: 'Represents a cloud-init nocloud user data
+                              source More info: http://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html'
+                            properties:
+                              secretRef: {}
+                              userData:
+                                description: UserData contains NoCloud inline cloud-init
+                                  userdata
+                                type: string
+                              userDataBase64:
+                                description: UserDataBase64 contains NoCloud cloud-init
+                                  userdata as a base64 encoded string
+                                type: string
+                          emptyDisk:
+                            description: EmptyDisk represents a temporary disk which
+                              shares the vms lifecycle
+                            properties:
+                              capacity: {}
+                            required:
+                            - capacity
+                          ephemeral:
+                            properties:
+                              persistentVolumeClaim: {}
+                          name:
+                            description: 'Volume''s name. Must be a DNS_LABEL and
+                              unique within the vm. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          persistentVolumeClaim: {}
+                          registryDisk:
+                            description: Represents a docker image with an embedded
+                              disk
+                            properties:
+                              image:
+                                description: Image is the name of the image with the
+                                  embedded disk
+                                type: string
+                              imagePullSecret:
+                                description: ImagePullSecret is the name of the Docker
+                                  registry secret required to pull the image. The
+                                  secret must already exist.
+                                type: string
+                            required:
+                            - image
+                        required:
+                        - name
+                      type: array
+                  required:
+                  - domain
+          required:
+          - running
+          - template
+        status:
+          description: OfflineVirtualMachineStatus represents the status returned
+            by the controller to describe how the OfflineVirtualMachine is doing
+          properties:
+            conditions:
+              description: Hold the state information of the OfflineVirtualMachine
+                and its VirtualMachine
+              items:
+                description: OfflineVirtualMachineCondition represents the state of
+                  OfflineVirtualMachine
+                properties:
+                  lastProbeTime: {}
+                  lastTransitionTime: {}
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+              type: array
+            created:
+              description: Created indicates if the virtual machine is created in
+                the cluster
+              type: boolean
+            ready:
+              description: Ready indicates if the virtual machine is running and ready
+              type: boolean
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+


### PR DESCRIPTION
This change allows kubevirt-ansible to consume a jinja2 template rather than a pre-rendered manifest from kubevirt.

For now, we include a jinja2 version, but the aim is to have upstream kubevirt maintain it. Otherwise we'll have to set up some system to automatically create a new j2 when upstream changes.

This replaces messed up PR#253