### PR TITLE
This change will introduced a dedicated playbook for the apb.

### DIFF
--- a/playbooks/apb-kubevirt.yml
+++ b/playbooks/apb-kubevirt.yml
@@ -1,0 +1,10 @@
+- hosts: localhost
+  connection: local
+  gather_facts: False
+  # unset http_proxy. required for running in the CI
+  environment:
+    http_proxy: ""
+  roles:
+    - role: kubevirt
+
+- import_playbook: "{{ playbook_dir }}/storage.yml"

--- a/playbooks/apb-kubevirt.yml
+++ b/playbooks/apb-kubevirt.yml
@@ -6,5 +6,3 @@
     http_proxy: ""
   roles:
     - role: kubevirt
-
-- import_playbook: "{{ playbook_dir }}/storage.yml"


### PR DESCRIPTION
A number of issues were raised around the playbooks executing on
`hosts: localhost` where they should be run on an oc/k8s master node.
However that breaks the ansible playbook bundle [0]. This change will add a dedicated playbook
for the apb.

[0]: https://github.com/ansibleplaybookbundle/kubevirt-apb/blob/b471ef705517b96cb02254451b4dde923e062e56/playbooks/provision.yml#L10