### PR TITLE
break out docker_prefix var and update README

### DIFF
--- a/roles/kubevirt/README.md
+++ b/roles/kubevirt/README.md
@@ -12,7 +12,8 @@ Deploy KubeVirt resources onto a cluster.
 |apb_action|provision| <ul><li>provision</li><li>deprovision</li></ul>|Action to perform.|
 |release_manifest_url|https://github.com/kubevirt/kubevirt/releases/download|||
 |kubevirt_template_dir|./templates||Location of the deployment template file.|
-|docker_prefix| kubevirt | |Container image organization.|
+|registr_prefix | kubevirt | |Container image organization.|
+|registr_url | docker.io | |Container image registry.|
 | storage_role | storage-none | <ul><li>storage-none</li><li>storage-demo</li><li>storage-glusterfs</li></ul> | Storage role to install with KubeVirt.|
 | version |0.6.0|<ul><li>0.6.0</li><li>0.5.0</li><li>0.4.1</li><li>0.4.0</li><li>0.3.0</li><li>0.2.0</li><li>0.1.0</li></ul>|KubeVirt release version.|
 |default_vm_templates|<ul><li>vm-template-fedora</li><li>vm-template-windows2012r2</li><li>vm-template-rhel7></ul>|| Default vm templates to deploy with KubeVirt.|

--- a/roles/kubevirt/defaults/main.yml
+++ b/roles/kubevirt/defaults/main.yml
@@ -1,6 +1,7 @@
 namespace: "kube-system"
 registry_url: "docker.io"
-docker_prefix: "{{ registry_url }}/kubevirt"
+registry_namespace: "kubevirt"
+docker_prefix: "{{ registry_url }}/{{ registry_namespace }}"
 cluster: "openshift"
 apb_action: "provision"
 release_manifest_url: "https://github.com/kubevirt/kubevirt/releases/download"


### PR DESCRIPTION
This PR splits out the docker_registry variable better to align with upstream kubevirt vs. what we want to control.

Also updated README to reflect new vars.