### PR TITLE
Always use the j2 from kubevirt releases

### DIFF
--- a/roles/kubevirt/tasks/provision.yml
+++ b/roles/kubevirt/tasks/provision.yml
@@ -27,9 +27,9 @@
     path: "{{ kubevirt_template_dir }}/kubevirt.yaml.j2"
   register: byo_template
 
-- name: Check for offline v{{ version }} templates in {{ offline_template_dir }}
+- name: Check for kubevirt.yaml.j2 version v{{ version }} in {{ offline_template_dir }}
   stat:
-    path: "{{ offline_template_dir }}/v{{ version }}/kubevirt.yaml"
+    path: "{{ offline_template_dir }}/v{{ version }}/kubevirt.yaml.j2"
   register: offline_templates
   when: byo_template.stat.exists == False
 
@@ -39,11 +39,11 @@
     dest: "{{ kubevirt_template_dir }}/kubevirt.yaml.j2"
   when: byo_template.stat.exists == False and offline_templates.stat.exists == False
 
-- name: Copy offline templates to /tmp
-  copy:
-    src: "{{ offline_template_dir }}/v{{ version }}/kubevirt.yaml"
+- name: Render offline template
+  template:
+    src: "{{ offline_template_dir }}/v{{ version }}/kubevirt.yaml.j2"
     dest: "/tmp/kubevirt.yaml"
-  when: offline_templates.changed and offline_templates.stat.exists == True
+  when: offline_templates.stat.exists == True
 
 - name: Render KubeVirt Yaml
   template:
@@ -85,12 +85,12 @@
 - name: Set the default VM templates URL
   set_fact:
     templates_url: "https://raw.githubusercontent.com/kubevirt/kubevirt/v{{ version }}/cluster/examples"
-  when: version[2] | int > 6
+  when: "{{ '0.6.0' is version(version, '<') }}"
 
 - name: Set the default VM templates URL
   set_fact:
     templates_url: "https://raw.githubusercontent.com/kubevirt/kubevirt/v{{ version }}/cluster"
-  when: version[2] | int < 7
+  when: "{{ '0.6.0' is version(version, '>=') }}"
 
 - name: Download KubeVirt default VM templates
   get_url:


### PR DESCRIPTION

(cherry picked from commit 61500fc8dd66fd6f55f5fcba28de154706a6dc36)