### PR TITLE
Variable to specify upstream Kubernetes version

### DIFF
--- a/playbooks/README.md
+++ b/playbooks/README.md
@@ -80,6 +80,14 @@ Make sure that you have **passwordless ssh access** to all machines of the clust
 $ ansible-playbook -i inventory playbooks/cluster/kubernetes/config.yml
 ```
 
+To deploy a specific version of Kubernetes, you can use the kubernetes_version
+variable listed in vars/all.yml. If vars/all.yml is not included the latest
+version will be installed.
+
+```bash
+$ ansible-playbook -i inventory -e@vars/all.yml playbooks/cluster/kubernetes/config.yml
+```
+
 ### OpenShift cluster
 
 Be sure that you have an **extra disk** attached to your machines

--- a/roles/kubernetes-prerequisites/tasks/main.yml
+++ b/roles/kubernetes-prerequisites/tasks/main.yml
@@ -57,6 +57,13 @@
 - name: update repo cache for kubernetes repo
   command: yum -q makecache -y --disablerepo=* --enablerepo=kubernetes
 
+- name: install kubelet kubeadm kubectl with version
+  command: >
+    yum install -y kubelet-{{ kubernetes_version }}
+    kubectl-{{ kubernetes_version }}
+    kubeadm-{{ kubernetes_version }}
+  when: kubernetes_version is defined
+
 - name: install all kubernetes packages
   package: 
     name: "{{ item }}"

--- a/vars/README.md
+++ b/vars/README.md
@@ -9,3 +9,4 @@ List of top level variables.
 | kubevirt_openshift_version | 3.10| <ul><li>3.10</li></ul>|OpenShift cluster version.|
 | version |0.13.3|<ul><li>0.13.3</li><li>0.9.6</li><li>0.8.0</li><li>0.7.0</li><li>0.6.0</li><li>0.5.0</li><li>0.4.1</li><li>0.4.0</li><li>0.3.0</li><li>0.2.0</li><li>0.1.0</li></ul>|KubeVirt release version.|
 | storage_role | storage-none | <ul><li>storage-none</li><li>storage-demo</li><li>storage-glusterfs</li></ul> | Storage role to install with KubeVirt.|
+| kubernetes_version | 1.10.5 | <ul><li>1.10.5</li></ul> | Kubernetes cluster version. |

--- a/vars/README.md
+++ b/vars/README.md
@@ -9,4 +9,4 @@ List of top level variables.
 | kubevirt_openshift_version | 3.10| <ul><li>3.10</li></ul>|OpenShift cluster version.|
 | version |0.13.3|<ul><li>0.13.3</li><li>0.9.6</li><li>0.8.0</li><li>0.7.0</li><li>0.6.0</li><li>0.5.0</li><li>0.4.1</li><li>0.4.0</li><li>0.3.0</li><li>0.2.0</li><li>0.1.0</li></ul>|KubeVirt release version.|
 | storage_role | storage-none | <ul><li>storage-none</li><li>storage-demo</li><li>storage-glusterfs</li></ul> | Storage role to install with KubeVirt.|
-| kubernetes_version | 1.10.5 | <ul><li>1.10.5</li></ul> | Kubernetes cluster version. |
+| kubernetes_version | 1.11.3 | <ul><li>1.11.3</li></ul> | Kubernetes cluster version. |

--- a/vars/all.yml
+++ b/vars/all.yml
@@ -34,3 +34,6 @@ kubevirt_web_ui_version: "v1.4.0-13"
 # Note: this assumes that PCI ID pools are the same on all nodes which may be
 # not the case in heterogeneous environment.
 sriov_pci_ids: ''
+
+### Kubernetes (upstream) ###
+kubernetes_version: '1.13.5'


### PR DESCRIPTION
We need a way to specify the version of Kuberbetes that is installed
because KubeVirt may not work on the latest upstream version.
For example, upstream is now on 1.11, but there are incompatibility
problems with latest, so we need the ability to install the previous
stable version, 1.10, until issues are resolved.