### PR TITLE
Update gluster DNS record

### DIFF
--- a/playbooks/provider/lago/LagoInitFile.yml.j2
+++ b/playbooks/provider/lago/LagoInitFile.yml.j2
@@ -99,5 +99,5 @@ nets:
     gw: 192.168.200.1
 {% if storage_role|default('') == 'storage-glusterfs' %}
     dns_records:
-      heketi-storage-app-storage.cloudapps.example.com: 192.168.200.3
+      heketi-storage-glusterfs.cloudapps.example.com: 192.168.200.3
 {% endif %}


### PR DESCRIPTION
The glusterfs namespace was changed from 'app-storage'
to 'glusterfs', so the DNS record should be changed accordingly.

Signed-off-by: gbenhaim <galbh2@gmail.com>