### PR TITLE
Set force to yes for get_url

### DIFF
--- a/roles/kubevirt/tasks/deprovision.yml
+++ b/roles/kubevirt/tasks/deprovision.yml
@@ -21,6 +21,7 @@
   get_url:
     url: "{{ release_manifest_url }}/v{{ version }}/demo-content.yaml"
     dest: "{{ kubevirt_template_dir }}/demo-content.yaml"
+    force: yes
   when: demo_content_manifest.stat.exists == False and byo_demo_content.stat.exists == False
 
 - name: Copy BYO Demo Content to /tmp
@@ -48,6 +49,7 @@
   get_url:
     url: "{{ release_manifest_url }}/v{{ version }}/kubevirt.yaml.j2"
     dest: "{{ kubevirt_template_dir }}/kubevirt.yaml.j2"
+    force: yes
   when: (kubevirt_template.stat.exists == False) and (byo_template.stat.exists == False)
 
 - name: Render KubeVirt template

--- a/roles/kubevirt/tasks/provision.yml
+++ b/roles/kubevirt/tasks/provision.yml
@@ -38,6 +38,7 @@
   get_url:
     url: "{{ release_manifest_url }}/v{{ version }}/kubevirt.yaml.j2"
     dest: "{{ kubevirt_template_dir }}/kubevirt.yaml.j2"
+    force: yes
   when: byo_template.stat.exists == False and offline_templates.stat.exists == False
 
 - name: Render offline template
@@ -71,6 +72,7 @@
   get_url:
     url: "{{ release_manifest_url }}/v{{ version }}/demo-content.yaml"
     dest: "{{ kubevirt_template_dir }}/demo-content.yaml"
+    force: yes
   when: byo_demo_content.stat.exists == False and offline_demo_content.stat.exists == False
 
 - name: Copy Offline Demo Content to /tmp
@@ -131,6 +133,7 @@
   get_url:
     url: "{{ templates_url }}/{{ item }}.yaml"
     dest: "/tmp/{{ item }}.yaml"
+    force: yes
   with_items:
     - "{{ default_vm_templates }}"
   when: cluster == "openshift" and "{{ byo_vm_templates.results | selectattr('stat.exists') | map(attribute='item') | list | length == 0 }}" and "{{ offline_vm_templates.results | selectattr('stat.exists') | map(attribute='item') | list | length == 0 }}"


### PR DESCRIPTION
Fixes #201.

If there is old kubevirt.yml or templates files under /tmp dir,
without force option, get_url will not download latest files.

Signed-off-by: Guohua Ouyang <gouyang@redhat.com>