### PR TITLE
Set reporting style for STDCI to plain HTML

### DIFF
--- a/stdci.yaml
+++ b/stdci.yaml
@@ -3,3 +3,6 @@ substage:
 
 runtime_requirements:
   support_nesting_level: 2
+
+reporting:
+  style: stdci


### PR DESCRIPTION
Make the links posted on tested PRs point to a static HTML file that
loads much faster then Blue Ocean.

Signed-off-by: gbenhaim <galbh2@gmail.com>