### PR TITLE
Use crio instead of docker

### DIFF
--- a/inventory
+++ b/inventory
@@ -5,8 +5,8 @@ etcd
 
 [OSEv3:vars]
 openshift_deployment_type=origin
-containerized=true
-openshift_image_tag=v3.10.0
+openshift_use_crio=true
+openshift_service_catalog_retries=150
 ansible_ssh_user=root
 openshift_master_identity_providers=[{'name': 'allow_all_auth', 'login': 'true', 'challenge': 'true', 'kind': 'AllowAllPasswordIdentityProvider'}]
 openshift_disable_check=memory_availability,disk_availability,docker_image_availability

--- a/playbooks/cluster/openshift/config.yml
+++ b/playbooks/cluster/openshift/config.yml
@@ -67,14 +67,7 @@
         - kexec-tools
         - sos
         - psacct
-        - docker
         - NetworkManager
-
-    - name: Enable and start docker service
-      service:
-        state: started
-        enabled: yes
-        name: docker
 
     - name: Enable and start NetworkManager service
       service:
@@ -83,14 +76,6 @@
         name: NetworkManager
 
 - import_playbook: "{{ openshift_ansible_dir }}/playbooks/prerequisites.yml"
-
-- hosts: masters nodes
-  remote_user: root
-  strategy: free
-  tasks:
-    - name: Pre-pull container images
-      shell: docker pull "{{ item }}"
-      with_items: "{{ container_images | default([]) }}"
 
 - import_playbook: "{{ openshift_ansible_dir | join_paths(openshift_playbook_path | default('playbooks/deploy_cluster.yml')) }}"
 

--- a/playbooks/cluster/openshift/vars/3.10.yml
+++ b/playbooks/cluster/openshift/vars/3.10.yml
@@ -1,7 +1,11 @@
-openshift_image_tag: v3.10.0
-openshift_service_catalog_image_version: "{{ openshift_image_tag }}"
+---
+openshift_pkg_version: -3.10.0
 openshift_additional_repos:
   - name: openshift-3.10.0-rc.0
     baseurl: https://plain.resources.ovirt.org/repos/origin/3.10/v3.10.0-rc.0/
+    enabled: yes
+    gpgcheck: no
+  - name: paas7-openshift-origin310-testing
+    baseurl: https://cbs.centos.org/repos/paas7-openshift-origin310-testing/x86_64/os/
     enabled: yes
     gpgcheck: no

--- a/playbooks/provider/lago/config.yml
+++ b/playbooks/provider/lago/config.yml
@@ -65,9 +65,18 @@
       delegate_to: localhost
       connection: local
 
-    - name: Set docker storage disk path
+    - name: Mount container storage
+      shell: |
+        disk="/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_2"
+        mount_path="/var/lib/containers"
+        findmnt --source "$disk" --target "$mount_path" && exit 0
+        mkdir -p "$mount_path"
+        mkfs.xfs "$disk"
+        echo -e "${disk}\t${mount_path}\txfs\tdefaults\t0 0" >> /etc/fstab
+        mount "$disk" "$mount_path"
+
+    - name: Set gluster disk idx
       set_fact:
-        container_runtime_docker_storage_setup_device: "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_2"
         gluster_disk_idx: "{{ '4' if inventory_hostname == groups['masters'][0] else '3' }}"
 
     - name: Set gluster disk path


### PR DESCRIPTION
crio is going to be the default container runtime in OC 3.11.
Let's adopt this change in order to catch bugs early as possible.

Details:

- /var/lib/containers will be used for crio persistent data.

- Set "containerized=false", since it's not supported with crio.

- Drop "pre-pull" container images, since we install using RPMs.

Signed-off-by: gbenhaim <galbh2@gmail.com>