### PR TITLE
Enable privileged containers in the security context for CDI clone

### DIFF
--- a/roles/cdi/tasks/provision.yml
+++ b/roles/cdi/tasks/provision.yml
@@ -34,3 +34,5 @@
 - name: Create CDI deployment
   command: "kubectl apply -f /tmp/cdi-provision.yml -n {{ cdi_namespace }}"
 
+- name: Enable privileged containers in the security context
+  command: "oc adm policy add-scc-to-user privileged -z cdi-sa"


### PR DESCRIPTION
Fixes: https://github.com/kubevirt/kubevirt-ansible/issues/362
Signed-off-by: Shiyang Wang <shiywang@redhat.com>