### PR TITLE
kubevirt: fix condition error on render offline template task (#323)

### DIFF
--- a/roles/kubevirt/tasks/provision.yml
+++ b/roles/kubevirt/tasks/provision.yml
@@ -43,7 +43,7 @@
   template:
     src: "{{ offline_template_dir }}/v{{ version }}/kubevirt.yaml.j2"
     dest: "/tmp/kubevirt.yaml"
-  when: offline_templates.stat.exists == True
+  when: (offline_templates is not skipped) and (offline_templates.stat.exists == True)
 
 - name: Render KubeVirt Yaml
   template:


### PR DESCRIPTION
this condition might fail if the task which registers `offline_templates` is skipped.

Typical error:

```
The conditional check 'offline_templates.stat.exists == True' failed.
The error was: error while evaluating conditional
(offline_templates.stat.exists == True): 'dict object' has no attribute
'stat'
```

The idea is to check if `offline_templates` is skipped before trying to
evaluate `offline_templates.stat.exists`

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
(cherry picked from commit e9bc98023313f788dcc3db9c6f4c4cadeff43b14)