### PR TITLE
Install packages using the native packages manager

### DIFF
--- a/playbooks/cluster/openshift/config.yml
+++ b/playbooks/cluster/openshift/config.yml
@@ -52,22 +52,21 @@
         - ansible_distribution in ["CentOS","RedHat"]
 
     - name: Install openshift requirements
-      package:
-        name: "{{ item }}"
-      with_items:
-        - python-yaml
-        - python-ipaddress
-        - wget
-        - git
-        - net-tools
-        - bind-utils
-        - iptables-services
-        - bridge-utils
-        - bash-completion
-        - kexec-tools
-        - sos
-        - psacct
-        - NetworkManager
+      yum:
+        name:
+          - python-yaml
+          - python-ipaddress
+          - wget
+          - git
+          - net-tools
+          - bind-utils
+          - iptables-services
+          - bridge-utils
+          - bash-completion
+          - kexec-tools
+          - sos
+          - psacct
+          - NetworkManager
 
     - name: Enable and start NetworkManager service
       service:


### PR DESCRIPTION
The "package" module doen't have the same optimization as the "yum:
module when installing multiple packages.

Since we are not testing on Fedora images, there is no need to also use the
"dnf" moudle.

Signed-off-by: gbenhaim <galbh2@gmail.com>