### PR TITLE
Fix cdi provision for upstream Kubernetes

### DIFF
--- a/roles/cdi/tasks/provision.yml
+++ b/roles/cdi/tasks/provision.yml
@@ -60,3 +60,4 @@
 
 - name: Enable privileged containers in the security context
   command: "oc adm policy add-scc-to-user privileged -z cdi-sa -n {{ cdi_namespace }}"
+  when: cli.stdout == "oc"


### PR DESCRIPTION
The task to enable priviledged containers in the security context
is only required for OpenShift so limited that task to when the
cli is oc and not kubectl. This task currently fails on upstream
K8S.

Fixes: https://github.com/kubevirt/kubevirt-ansible/issues/398