### PR TITLE
Change default Multus CNI from flannel to weave-net

### DIFF
--- a/roles/network-multus/defaults/main.yml
+++ b/roles/network-multus/defaults/main.yml
@@ -26,11 +26,9 @@ kubernetes_cni_config: |
     "type": "multus",
     "delegates": [
      {
-       "type": "flannel",
-       "name": "flannel.1",
-       "delegate": {
-         "isDefaultGateway": true
-       }
+       "type": "weave-net",
+       "name": "weave-net.1",
+       "hairpinMode": true
      }
     ],
     "kubeconfig": "/etc/cni/net.d/multus.d/multus.kubeconfig"


### PR DESCRIPTION
**What this PR does / why we need it**:
For upstream kubernetes, it should default to weave-net because
that is what the kubernetes-master role installs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubevirt/kubevirt-ansible/issues/401

**Special notes for your reviewer**:

**Release note**:
```release-note
Changed default Multus CNI from flannel to weave-net for upstream kubernetes. It was changed to weave-net because that is the CNI kubevirt-ansible installs.
```