### PR TITLE
cdi: Apply privileged scc to the correct namespace

### DIFF
--- a/roles/cdi/tasks/provision.yml
+++ b/roles/cdi/tasks/provision.yml
@@ -35,4 +35,4 @@
   command: "kubectl apply -f /tmp/cdi-provision.yml -n {{ cdi_namespace }}"
 
 - name: Enable privileged containers in the security context
-  command: "oc adm policy add-scc-to-user privileged -z cdi-sa"
+  command: "oc adm policy add-scc-to-user privileged -z cdi-sa -n {{ cdi_namespace }}"


### PR DESCRIPTION
When creating the privileged scc for CDI (to enable cloning) we need to
apply it to the namespace where CDI is installed (not always 'default').

Signed-off-by: Adam Litke <alitke@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
Fixed CDI installation by applying the privileged scc to the correct namespace.
```
