### PR TITLE
Adding image_pull_policy

### DIFF
--- a/roles/kubevirt/defaults/main.yml
+++ b/roles/kubevirt/defaults/main.yml
@@ -8,6 +8,7 @@ release_manifest_url: "https://github.com/kubevirt/kubevirt/releases/download"
 kubevirt_template_dir: "{{ role_path }}/templates"
 version: 0.6.2
 docker_tag: "v{{ version }}"
+image_pull_policy: IfNotPresent
 
 offline_template_dir: "/opt/apb/kubevirt-templates"
 

--- a/vars/all.yml
+++ b/vars/all.yml
@@ -9,6 +9,7 @@ openshift_playbook_path: "{{ openshift_ansible_dir }}/{{ 'playbooks/byo/config.y
 
 ### KubeVirt ###
 version: 0.6.2
+image_pull_policy: IfNotPresent
 
 ### Components ###
 storage_role: "storage-none"


### PR DESCRIPTION
image_pull_policy variable is required by kubevirt's manifests

Signed-off-by: gbenhaim <galbh2@gmail.com>
(cherry picked from commit f0eb0afb18553971f68b5289aa547c6795923c4d)

```release-note
NONE
```
