### PR TITLE
Increase Gluster's deployment timeout

### DIFF
--- a/playbooks/cluster/openshift/vars/gluster.yml
+++ b/playbooks/cluster/openshift/vars/gluster.yml
@@ -8,3 +8,4 @@ openshift_storage_glusterfs_storageclass_default: true
 openshift_storage_glusterfs_block_deploy: false
 # Disable any other default StorageClass
 openshift_storageclass_default: false
+openshift_storage_glusterfs_timeout: 900


### PR DESCRIPTION
Once in a while the deployment fails because of a timeout (which in most
cases is a false positive). Let's increase the timeout.

Signed-off-by: gbenhaim <galbh2@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
