### PR TITLE
Infra fixes

### DIFF
--- a/automation/check-patch.sh
+++ b/automation/check-patch.sh
@@ -211,7 +211,10 @@ run() {
 	"storage_role=$storage_role"
     )
 
-    make generate-tests &> "${ARTIFACTS_PATH}/generate-tests.log" &
+    timeout \
+        --kill-after 5m \
+        20m \
+        make generate-tests &> "${ARTIFACTS_PATH}/generate-tests.log" &
     readonly MAKE_TESTS_PID="$!"
 
     ansible-playbook \

--- a/hack/build-tests.sh
+++ b/hack/build-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 source hack/common.sh
 

--- a/hack/dockerized.sh
+++ b/hack/dockerized.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 
 source $(dirname "$0")/common.sh
 

--- a/hack/dockerized.sh
+++ b/hack/dockerized.sh
@@ -56,7 +56,7 @@ _rsync() {
 }
 
 # Copy kubevirt into the persistent docker volume
-_rsync --delete --exclude _out ${KUBEVIRT_ANSIBLE_DIR}/ "rsync://root@127.0.0.1:${RSYNCD_PORT}/build"
+_rsync --delete --exclude _out --exclude deployment-openshift ${KUBEVIRT_ANSIBLE_DIR}/ "rsync://root@127.0.0.1:${RSYNCD_PORT}/build"
 
 # Run the command
 test -t 1 && USE_TTY="-it"

--- a/playbooks/cluster/openshift/vars/gluster.yml
+++ b/playbooks/cluster/openshift/vars/gluster.yml
@@ -8,3 +8,4 @@ openshift_storage_glusterfs_storageclass_default: true
 openshift_storage_glusterfs_block_deploy: false
 # Disable any other default StorageClass
 openshift_storageclass_default: false
+openshift_storage_glusterfs_timeout: 900


### PR DESCRIPTION
#### oc deployment

- Increase Gluster's deployment timeout

#### Test compilation 

- Compile with timeout
- Set trace in the compilation scripts
- Don't copy VM images to the test builder container

```release-note
None
```
