### PR TITLE
Optional cni plugins deployment

### DIFF
--- a/roles/network-multus/defaults/main.yml
+++ b/roles/network-multus/defaults/main.yml
@@ -7,6 +7,7 @@ multus_provisioner_release: "latest"
 
 cni_provisioner_repo: "quay.io/schseba/cni-plugins"
 cni_provisioner_release: "latest"
+network_multus_deploy_cni_plugins: true
 
 openshift_cni_config: |
   '{

--- a/roles/network-multus/tasks/provision.yml
+++ b/roles/network-multus/tasks/provision.yml
@@ -47,14 +47,16 @@
   - name: Create multus Resources
     shell: "{{ cluster_command }} apply -f /tmp/multus.yml"
 
-  - name: Render cni plugins deployment yaml
-    template:
-      src: cni-plugins.yml
-      dest: /tmp/cni-plugins.yml
+  - name: Deploy cni plugins
+    when: network_multus_deploy_cni_plugins
+    block:
+      - name: Render cni plugins deployment yaml
+        template:
+          src: cni-plugins.yml
+          dest: /tmp/cni-plugins.yml
 
-  - name: Create cni plugins Resources
-    shell: "{{ cluster_command }} apply -f /tmp/cni-plugins.yml"
-
+      - name: Create cni plugins Resources
+        shell: "{{ cluster_command }} apply -f /tmp/cni-plugins.yml"
 
   - name: Wait until multus is running
     shell: "{{ cluster_command }} -n {{ namespace }} get daemonset | grep {{ item }} | awk \'{ if ($3 == $4) print \"0\"; else print \"1\"}\'"


### PR DESCRIPTION
Allow the user to decide if cni plugins deployment is needed,
the default is true.

Signed-off-by: gbenhaim <galbh2@gmail.com>

```release-note
None
```
