### PR TITLE
Increase Nodes RAM

### DIFF
--- a/playbooks/provider/lago/LagoInitFile.yml.j2
+++ b/playbooks/provider/lago/LagoInitFile.yml.j2
@@ -18,7 +18,7 @@ host-settings: &nodes-settings
 {% else %}
     groups: [nodes]
 {% endif %}
-    memory: 2047
+    memory: 3072
     disks:
       - template_name: {{ lago_vm_image }}
         type: template


### PR DESCRIPTION
We keep adding more components to the deployment,
which cause the nodes RAM run out.
Adding 1GB of RAM to each node (except from the master which already
has 4GB). Now each node has 3GB of RAM.

Signed-off-by: gbenhaim <galbh2@gmail.com>


```release-note
None
```
