### PR TITLE
Reduce required parameters for kubevirt-web-ui playbook

### DIFF
--- a/playbooks/kubevirt-web-ui/README.md
+++ b/playbooks/kubevirt-web-ui/README.md
@@ -12,6 +12,7 @@ The playbook is based on [opensift-ansible](https://github.com/openshift/openshi
 - `openshift_master_default_subdomain`
   - example: `router.default.svc.cluster.local`
   - Used for composition of web-ui's public URL
+  - If not set, the default is retrieved from openshift-ansible deployment
 - `public_master_hostname`
   - example: `master:8443`
   - Public URL of your first master node, used for composition of public `console` URL for redirects

--- a/playbooks/kubevirt-web-ui/README.md
+++ b/playbooks/kubevirt-web-ui/README.md
@@ -7,12 +7,15 @@ The playbook is based on [opensift-ansible](https://github.com/openshift/openshi
 - `kubevirt_web_ui_image_name`
   - example: docker.io/mareklibra/kubevirt-web-ui:f679e704219f58aea97a1433ea01e7c7227afc7d
   - The docker image with the kubevirt-web-ui application
+
+### Optional Variables:
 - `openshift_master_default_subdomain`
   - example: `router.default.svc.cluster.local`
   - Used for composition of web-ui's public URL
 - `public_master_hostname`
   - example: `master:8443`
   - Public URL of your first master node, used for composition of public `console` URL for redirects
+  - If not set, the default is retrieved from openshift-ansible deployment
 
 ## How To Run
 ### Prerequisities

--- a/playbooks/kubevirt-web-ui/inventory_example.ini
+++ b/playbooks/kubevirt-web-ui/inventory_example.ini
@@ -5,12 +5,13 @@ masters
 ssh_args='-i ~/.ssh/id_rsa'
 
 [OSEv3:vars]
-# The kubevirt-web-ui docker image
+# Required. The kubevirt-web-ui docker image
 kubevirt_web_ui_image_name = "docker.io/mareklibra/kubevirt-web-ui:f679e704219f58aea97a1433ea01e7c7227afc7d"
 
+# Optional: If not set, the value is gathered from the openshift-console's ConfigMap.
 # Used for composition of public kubevirt-web-ui URL
 # example: router.default.svc.cluster.local
-openshift_master_default_subdomain = your.app.subdomain.host.com
+# openshift_master_default_subdomain = your.app.subdomain.host.com
 
 # Optional. If not set, the value is gathered from the openshift-console's ConfigMap.
 # Used for composition of URLs for "console" and public master

--- a/playbooks/kubevirt-web-ui/inventory_example.ini
+++ b/playbooks/kubevirt-web-ui/inventory_example.ini
@@ -12,9 +12,10 @@ kubevirt_web_ui_image_name = "docker.io/mareklibra/kubevirt-web-ui:f679e704219f5
 # example: router.default.svc.cluster.local
 openshift_master_default_subdomain = your.app.subdomain.host.com
 
+# Optional. If not set, the value is gathered from the openshift-console's ConfigMap.
 # Used for composition of URLs for "console" and public master
 # example: master.host.com:8443 
-public_master_hostname = your.public.master.host.com 
+# public_master_hostname = your.public.master.host.com 
 
 ansible_ssh_user = root
 

--- a/roles/kubevirt_web_ui/defaults/main.yml
+++ b/roles/kubevirt_web_ui/defaults/main.yml
@@ -1,23 +1,14 @@
 ---
-# Required param:
-# - kubevirt_web_ui_image_name
-#
-# TODO: gather automatically
-# - openshift_master_default_subdomain
-# - public_master_hostname
+openshift_client_binary: "oc"
 
 kubevirt_web_ui_nodeselector: {"node-role.kubernetes.io/master":"true"}
 
 __console_template_file: "console-template.yaml"
 __console_config_file: "console-config.yaml"
 
-# Provide image explicitely
-# kubevirt_web_ui_image_name: "docker.io/mareklibra/kubevirt-web-ui:f679e704219f58aea97a1433ea01e7c7227afc7d"
-
 # Default the replica count to the number of masters.
 kubevirt_web_ui_replica_count: "1"
 
-kubevirt_web_ui_hostname: "kubevirt-web-ui.{{openshift_master_default_subdomain}}"
 kubevirt_web_ui_cert: ""
 kubevirt_web_ui_key: ""
 kubevirt_web_ui_ca: ""
@@ -26,15 +17,6 @@ kubevirt_web_ui_auth_ca_file: "/var/run/secrets/kubernetes.io/serviceaccount/ca.
 
 kubevirt_web_ui_documentation_base_url: "https://docs.openshift.com/container-platform/3.11/"
 
-######
-# Mimic openshift-ansible
-openshift_client_binary: "oc"
-
 openshift:
   common:
-    config_base: "/etc/origin"  # as hardcoded in playbooks/cluster/openshift/config.yml
-  master:
-    public_console_url: "https://{{ public_master_hostname }}/console" # Example: https://master.mycluster.com:8443/console
-    public_api_url: "https://{{ public_master_hostname }}" 
-    logout_url: "" # TODO: not needed so far
-
+    config_base: "/etc/origin" # as hardcoded in playbooks/cluster/openshift/config.yml

--- a/roles/kubevirt_web_ui/tasks/console-config.yml
+++ b/roles/kubevirt_web_ui/tasks/console-config.yml
@@ -17,7 +17,7 @@
       lineinfile:
         path: "{{ mktemp.stdout }}/{{ __console_config_file }}"
         regexp: "^  masterPublicURL:.*$"
-        line: "  masterPublicURL: '{{ openshift.master.public_api_url }}'"
+        line: "  masterPublicURL: '{{ openshift_master_public_api_url }}'"
     - name: Change oauthEndpointCAFile
       lineinfile:
         path: "{{ mktemp.stdout }}/{{ __console_config_file }}"
@@ -27,7 +27,7 @@
       lineinfile:
         path: "{{ mktemp.stdout }}/{{ __console_config_file }}"
         regexp: "^  logoutRedirect:.*$"
-        line: "  logoutRedirect: '{{ openshift.master.logout_url | default('') }}'"
+        line: "  logoutRedirect: '{{ openshift_master_logout_url | default('') }}'"
     - name: Change documentationBaseURL
       lineinfile:
         path: "{{ mktemp.stdout }}/{{ __console_config_file }}"

--- a/roles/kubevirt_web_ui/tasks/install.yml
+++ b/roles/kubevirt_web_ui/tasks/install.yml
@@ -45,7 +45,7 @@
 
 - set_fact:
     # Must have a trailing slash
-    console_picker_developer_console_public_url: "{{ openshift.master.public_console_url }}/"
+    console_picker_developer_console_public_url: "{{ openshift_master_public_console_url }}/"
   when: (openshift_web_console_enable_context_selector | default(true) | bool) and (openshift_web_console_install | default(true) | bool)
 
 - set_fact: console_cert={{ lookup('file', kubevirt_web_ui_cert) }}

--- a/roles/kubevirt_web_ui/tasks/main.yml
+++ b/roles/kubevirt_web_ui/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
 # do any asserts here
+- include_tasks: required_params.yml
 
 - include_tasks: install.yml
   when: kubevirt_web_ui_install | default(true) | bool

--- a/roles/kubevirt_web_ui/tasks/required_params.yml
+++ b/roles/kubevirt_web_ui/tasks/required_params.yml
@@ -1,7 +1,4 @@
 ---
-# TODO: gather automatically
-# - openshift_master_default_subdomain
-
 #### Verify required variables
 
 - name: Verify required kubevirt_web_ui_image_name variable is set
@@ -9,23 +6,26 @@
     msg: kubevirt_web_ui_image_name must be set to deploy kubevirt-web-ui
   when: kubevirt_web_ui_image_name is not defined
 
-- name: Verify required openshift_master_default_subdomain variable is set
-  fail:
-    msg: openshift_master_default_subdomain must be set to deploy kubevirt-web-ui
-  when: openshift_master_default_subdomain is not defined
-
 #### Autodiscovery of missing variables
-
-# set public_master_hostname, assumptions:
+# Assumptions for autodiscovery:
 # - console's namespace is hardcoded to "openshift-console" (as done in openshift-ansible)
 # - the openshift console is mandatory part of OKD installation
+
 - name: Discover public_master_hostname from openshift console deployment
   shell: "{{ openshift_client_binary }} get configmap console-config -n openshift-console -o jsonpath='{.data}' | grep 'masterPublicURL:' | sed 's/^.*masterPublicURL: *http.*:\\/\\///g'"
-  register: parsedConfigMap
+  register: parsedMasterPublicURL
   when: public_master_hostname | default("") | string == ""
 
-- set_fact: public_master_hostname="{{ parsedConfigMap.stdout }}"
-  when: public_master_hostname | default("") | string == ""
+- set_fact: public_master_hostname="{{ parsedMasterPublicURL.stdout }}"
+  when: public_master_hostname | default("") | string == "" and parsedMasterPublicURL.stdout != ""
+
+- name: Discover openshift_master_default_subdomain from openshift console deployment
+  shell: "{{ openshift_client_binary }} get configmap console-config -n openshift-console -o jsonpath='{.data}' | grep 'consoleBaseAddress:' | sed 's/^.*consoleBaseAddress: *http.*:\\/\\/console\\.//g'"
+  register: parsedBaseAddress
+  when: openshift_master_default_subdomain | default("") | string == ""
+
+- set_fact: openshift_master_default_subdomain="{{ parsedBaseAddress.stdout }}"
+  when: openshift_master_default_subdomain | default("") | string == "" and parsedBaseAddress.stdout != ""
 
 #### Set derived constants
 

--- a/roles/kubevirt_web_ui/tasks/required_params.yml
+++ b/roles/kubevirt_web_ui/tasks/required_params.yml
@@ -1,0 +1,38 @@
+---
+# TODO: gather automatically
+# - openshift_master_default_subdomain
+
+#### Verify required variables
+
+- name: Verify required kubevirt_web_ui_image_name variable is set
+  fail:
+    msg: kubevirt_web_ui_image_name must be set to deploy kubevirt-web-ui
+  when: kubevirt_web_ui_image_name is not defined
+
+- name: Verify required openshift_master_default_subdomain variable is set
+  fail:
+    msg: openshift_master_default_subdomain must be set to deploy kubevirt-web-ui
+  when: openshift_master_default_subdomain is not defined
+
+#### Autodiscovery of missing variables
+
+# set public_master_hostname, assumptions:
+# - console's namespace is hardcoded to "openshift-console" (as done in openshift-ansible)
+# - the openshift console is mandatory part of OKD installation
+- name: Discover public_master_hostname from openshift console deployment
+  shell: "{{ openshift_client_binary }} get configmap console-config -n openshift-console -o jsonpath='{.data}' | grep 'masterPublicURL:' | sed 's/^.*masterPublicURL: *http.*:\\/\\///g'"
+  register: parsedConfigMap
+  when: public_master_hostname | default("") | string == ""
+
+- set_fact: public_master_hostname="{{ parsedConfigMap.stdout }}"
+  when: public_master_hostname | default("") | string == ""
+
+#### Set derived constants
+
+- set_fact: kubevirt_web_ui_hostname="kubevirt-web-ui.{{openshift_master_default_subdomain}}"
+
+# Mimic openshift-ansible
+- set_fact: openshift_master_public_console_url="https://{{ public_master_hostname }}/console" # Example: https://master.mycluster.com:8443/console
+- set_fact: openshift_master_public_api_url="https://{{ public_master_hostname }}"
+- set_fact: openshift_master_logout_url="" # TODO: not needed so far
+


### PR DESCRIPTION
**What**: If not set by the user, gather the `public_master_hostname` and `openshift_master_default_subdomain` parameters automatically

With this change, the only required attribute is the `kubevirt_web_ui_image_name` (docker image).

**Special notes for your reviewer**:
The values of `public_master_hostname` and `openshift_master_default_subdomain` are gathered only if not provided by the user explicitly.
These fact defaults are gathered from openshift-console deployment, assuming it's namespace and URL compositions as hardcoded within openshift-ansible. If this assumption is not met, the fallback value is empty string ("").

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The "public_master_hostname" and "openshift_master_default_subdomain" parameters of the "kubevirt-web-ui" playbook are optional now. If not provided explicitly, they are determined from the existing openshift-console deployment.
```
