### PR TITLE
kubevirt-web-ui: deprovision removes OAuthClient

### DIFF
--- a/roles/kubevirt_web_ui/tasks/remove.yml
+++ b/roles/kubevirt_web_ui/tasks/remove.yml
@@ -1,7 +1,7 @@
 ---
 - name: Remove kubevirt-web-ui project
-  oc_project:
-    name: kubevirt-web-ui
-    state: absent
+  shell: "{{ openshift_client_binary }} delete project kubevirt-web-ui"
 
-# TODO: Remove OAuthClient
+- name: Remove Kubevirt Web UI OAuth client
+  shell: "{{ openshift_client_binary }} delete oauthclient kubevirt-web-ui"
+


### PR DESCRIPTION
**What this PR does**: At deprovision, the OAuthClient object is removed

As it is created by `provision` task.

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
