### PR TITLE
Use Kubevirt Fail handler

### DIFF
--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -8,10 +8,11 @@ import (
 
 	"kubevirt.io/kubevirt-ansible/tests"
 	"kubevirt.io/qe-tools/pkg/ginkgo-reporters"
+	ktests "kubevirt.io/kubevirt/tests"
 )
 
 func TestTests(t *testing.T) {
-	RegisterFailHandler(Fail)
+	RegisterFailHandler(ktests.KubevirtFailHandler)
 	reporters := make([]Reporter, 0)
 	if ginkgo_reporters.Polarion.Run {
 		reporters = append(reporters, &ginkgo_reporters.Polarion)


### PR DESCRIPTION
Kubevirt's fail handler prints pod information on failure,
that could be useful for debugging.

Signed-off-by: gbenhaim <galbh2@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
