### PR TITLE
Use a static version for glusterfs server image

### DIFF
--- a/playbooks/cluster/openshift/vars/3.10.yml
+++ b/playbooks/cluster/openshift/vars/3.10.yml
@@ -1,7 +1,2 @@
 ---
 openshift_pkg_version: -3.10.0
-openshift_additional_repos:
-  - name: paas7-openshift-origin310-testing
-    baseurl: https://cbs.centos.org/repos/paas7-openshift-origin310-testing/x86_64/os/
-    enabled: yes
-    gpgcheck: no

--- a/playbooks/cluster/openshift/vars/gluster.yml
+++ b/playbooks/cluster/openshift/vars/gluster.yml
@@ -9,3 +9,4 @@ openshift_storage_glusterfs_block_deploy: false
 # Disable any other default StorageClass
 openshift_storageclass_default: false
 openshift_storage_glusterfs_timeout: 900
+openshift_storage_glusterfs_image: gluster/gluster-centos:gluster4u0_centos7


### PR DESCRIPTION
Will reduce failures regard to Gluster deployment.

Signed-off-by: gbenhaim <galbh2@gmail.com>

```release-note
None
```
