### PR TITLE
Deprovision is missing args

### DIFF
--- a/automation/check-patch.sh
+++ b/automation/check-patch.sh
@@ -240,6 +240,7 @@ run() {
         -i "$inventory_file" \
         -v \
         -e "apb_action=deprovision" \
+        -e "${args[*]}" \
         playbooks/automation/deprovision.yml
 }
 


### PR DESCRIPTION
When deprovision is run, args like `cluster` are left out.


```release-note
NONE
```
