### PR TITLE
web-ui: Use default image from quay.io

### DIFF
--- a/inventory
+++ b/inventory
@@ -17,7 +17,7 @@ openshift_install_examples=false
 openshift_master_default_subdomain=cloudapps.example.com
 
 # Image used for the kubevirt/web-ui deployment
-kubevirt_web_ui_image_name=docker.io/mareklibra/kubevirt-web-ui:v1.3-8
+kubevirt_web_ui_image_name=quay.io/kubevirt/kubevirt-web-ui:v1.3-9
 # Master public API URL
 public_master_hostname=openshift.cloudapps.example.com:443
 

--- a/playbooks/kubevirt-web-ui/README.md
+++ b/playbooks/kubevirt-web-ui/README.md
@@ -7,7 +7,7 @@ The playbook is based on [opensift-ansible](https://github.com/openshift/openshi
 - `cluster`
   - To install Kubevirt Web UI, please set `cluster=openshift`
 - `kubevirt_web_ui_image_name`
-  - example: docker.io/mareklibra/kubevirt-web-ui:f679e704219f58aea97a1433ea01e7c7227afc7d
+  - example: quay.io/kubevirt/kubevirt-web-ui:latest
   - The docker image with the kubevirt-web-ui application
 
 ### Optional Variables:

--- a/playbooks/kubevirt-web-ui/inventory_example.ini
+++ b/playbooks/kubevirt-web-ui/inventory_example.ini
@@ -6,7 +6,7 @@ ssh_args='-i ~/.ssh/id_rsa'
 
 [OSEv3:vars]
 # Required. The kubevirt-web-ui docker image
-kubevirt_web_ui_image_name = "docker.io/mareklibra/kubevirt-web-ui:f679e704219f58aea97a1433ea01e7c7227afc7d"
+kubevirt_web_ui_image_name = "quay.io/kubevirt/kubevirt-web-ui:latest"
 
 # Optional: If not set, the value is gathered from the openshift-console's ConfigMap.
 # Used for composition of public kubevirt-web-ui URL

--- a/roles/kubevirt_web_ui/files/console-template.yaml
+++ b/roles/kubevirt_web_ui/files/console-template.yaml
@@ -12,7 +12,7 @@ metadata:
 parameters:
 - name: IMAGE
   # value: openshift/origin-console:latest
-  value: docker.io/mareklibra/kubevirt-web-ui:latest # TODO: point to "officil" upstream
+  value: quay.io/kubevirt/kubevirt-web-ui:latest
   required: true
 - name: NAMESPACE
   value: kubevirt-web-ui


### PR DESCRIPTION
The kubevirt-web-ui image is moved to quay.io:
  quay.io/kubevirt/kubevirt-web-ui:latest

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does**: Default image moved from private repo to kubevirt's offical

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
