### PR TITLE
Collect obj description on test failure

### DIFF
--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -11,8 +11,13 @@ import (
 	"kubevirt.io/qe-tools/pkg/ginkgo-reporters"
 )
 
+func CustomFailHandler(message string, callerSkip ...int) {
+	tests.CollectObjDescUsingTestDesc(CurrentGinkgoTestDescription())
+	ktests.KubevirtFailHandler(message, callerSkip...)
+}
+
 func TestTests(t *testing.T) {
-	RegisterFailHandler(ktests.KubevirtFailHandler)
+	RegisterFailHandler(CustomFailHandler)
 	reporters := make([]Reporter, 0)
 	if ginkgo_reporters.Polarion.Run {
 		reporters = append(reporters, &ginkgo_reporters.Polarion)

--- a/tests/util.go
+++ b/tests/util.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -36,6 +38,7 @@ const (
 	UsernameTestUser     = "kubevirt-test-user"
 	NamespaceTestDefault = "kubevirt-test-default"
 	UsernameAdminUser    = "test_admin"
+	PasswordAdminUser    = "123456"
 )
 
 const (
@@ -299,4 +302,162 @@ func OpenConsole(virtCli kubecli.KubevirtClient, vmiName string, vmiNamespace st
 		},
 		Check: func() bool { return true },
 	}, timeout, opts...)
+}
+
+func DescribeObject(name string, namespace string) (string, error) {
+	result, _, err := ktests.RunCommandWithNS(
+		namespace, "oc", "describe", name,
+	)
+	if err != nil {
+		return "", err
+	}
+
+	return result, nil
+}
+
+func DescribeObjects(namespace string, names []string) (map[string]string, error) {
+	m := make(map[string]string)
+
+	for _, name := range names {
+		desc, err := DescribeObject(name, namespace)
+		if err != nil {
+			return nil, err
+		}
+		m[name] = desc
+	}
+
+	return m, nil
+}
+
+func GetObjects(namespace string, objType string) ([]string, error) {
+	result, _, err := ktests.RunCommandWithNS(
+		namespace, "oc", "get", objType, "-o", "name",
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if result == "" {
+		return make([]string, 0), nil
+	}
+
+	return strings.Split(strings.Trim(result, "\n"), "\n"), nil
+}
+
+func GetNamespaces() ([]string, error) {
+	result, _, err := ktests.RunCommandWithNS("", "oc", "projects", "--short")
+	if err != nil {
+		return nil, err
+	}
+
+	return strings.Split(strings.Trim(result, "\n"), "\n"), nil
+}
+
+func DumpObjectsByType(namespace string, objType string, dest string) error {
+	var filename string
+	fullDest := filepath.Join(dest, namespace, objType)
+	names, err := GetObjects(namespace, objType)
+
+	if err != nil {
+		return err
+	}
+	m, err := DescribeObjects(namespace, names)
+
+	if err != nil {
+		return err
+	}
+
+	if len(m) == 0 {
+		return nil
+	}
+
+	os.MkdirAll(fullDest, 0770)
+
+	for name, desc := range m {
+		filename = filepath.Join(fullDest, filepath.Base(name))
+		err = ioutil.WriteFile(filename, []byte(desc), 0644)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func DumpObjects(namespace string, objTypes []string, dest string) error {
+	for _, objType := range objTypes {
+		err := DumpObjectsByType(namespace, objType, dest)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func CollectObjDesc(dest string, objTypes ...string) error {
+	namespaces, err := GetNamespaces()
+	if err != nil {
+		return err
+	}
+
+	for _, namespace := range namespaces {
+		err = DumpObjects(namespace, objTypes, dest)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func CollectObjDescUsingTestDesc(td GinkgoTestDescription) error {
+	testName := fmt.Sprintf(
+		"%s-%d",
+		filepath.Base(td.FileName),
+		td.LineNumber,
+	)
+	dest := filepath.Join("exported-artifacts", "obj-desc", "after", testName)
+
+	admin := User{Name: UsernameAdminUser, Password: PasswordAdminUser}
+	err := admin.Login()
+	if err != nil {
+		fmt.Printf(
+			"Failed to login as Admin user. Skipping obj desc collection",
+		)
+		return err
+	}
+
+	fmt.Println("Running log collection")
+	err = CollectObjDesc(dest, "pod", "pv", "pvc")
+
+	if err != nil {
+		fmt.Printf("Failed to collect logs\n%s", err)
+	}
+
+	err = DumpObjectsByType("default", "node", dest)
+	if err != nil {
+		fmt.Printf("Failed to collect nodes description\n %s", err)
+	}
+
+	return nil
+}
+
+type User struct {
+	Name     string
+	Password string
+}
+
+func (u *User) Login() error {
+	_, _, err := ktests.RunCommandWithNS(
+		"", "oc", "login",
+		"-u", u.Name,
+		"-p", u.Password,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
Collect the description of the requested objects type, from all
of the projects, on test failure. The following is an example of
the generated file tree:

exported-artifacts/
├── obj-desc
│   └── after
│       └── rbac_test.go-52
│           ├── default
│           │   ├── node
│           │   │   ├── lago-master
│           │   │   ├── lago-node0
│           │   │   └── lago-node1
│           │   └── pod
│           │       ├── docker-registry-1-hlwv2
│           │       ├── registry-console-1-ns4n9
│           │       ├── router-1-2mtvx
│           │       └── router-1-5srgx
│           ├── glusterfs
│           │   └── pod
│           │       ├── glusterfs-storage-x5vk5
│           │       ├── glusterfs-storage-zphsm

...

* The number in the test file name represents the line that caused the
  failure.

Signed-off-by: gbenhaim <galbh2@gmail.com>

```release-note
None
```
