### PR TITLE
Auto-compose of kubevirt_web_ui_image_name for kubevirt-apb flow

### DIFF
--- a/playbooks/kubevirt-web-ui/README.md
+++ b/playbooks/kubevirt-web-ui/README.md
@@ -3,12 +3,21 @@ Used for deployment of the [Kubevirt Web UI](https://github.com/kubevirt/web-ui)
 
 The playbook is based on [opensift-ansible](https://github.com/openshift/openshift-ansible/tree/master/playbooks/openshift-console).
 
+## Kubevirt Web UI Image name and tag
+One of following must be set:
+- either `kubevirt_web_ui_image_name` variable (when set, takes precedence over automatic composition of image:tag)
+  - example: quay.io/kubevirt/kubevirt-web-ui:latest
+  - The docker image with the kubevirt-web-ui application
+- or `registry_url, registry_namespace, docker_tag, version` (as used in kubevirt-apb flow)
+  - `registry_url` example: quay.io
+  - `registry_namespace` example: kubevirt
+  - one of following:
+    - `docker_tag` example: 1.3.0-3 or 1.3 (note: there's no 'v' preffixed)
+    - `version`  example: 0.9.3
+
 ### Required Variables
 - `cluster`
   - To install Kubevirt Web UI, please set `cluster=openshift`
-- `kubevirt_web_ui_image_name`
-  - example: quay.io/kubevirt/kubevirt-web-ui:latest
-  - The docker image with the kubevirt-web-ui application
 
 ### Optional Variables:
 - `openshift_master_default_subdomain`
@@ -28,8 +37,12 @@ From the hosts, just the master node is required.
 
 Please check `playbooks/kubevirt-web-ui/inventory_example.ini` for an example.
 
-### Invocation
+### Invocation examples
 ```
-ansible-playbook -i your_inventory_file.ini playbooks/kubevirt-web-ui/config.yml -e "apb_action=provision cluster=openshift"
+ansible-playbook -i your_inventory_file.ini playbooks/kubevirt-web-ui/config.yml -e "apb_action=provision cluster=openshift registry_url=quay.io registry_namespace=kubevirt docker_tag=1.3" # to mimic kubevirt-apb flow
+ansible-playbook -i your_inventory_file.ini playbooks/kubevirt-web-ui/config.yml -e "apb_action=provision cluster=openshift registry_url=quay.io registry_namespace=kubevirt"  # for :latest image tag
+ansible-playbook -i your_inventory_file.ini playbooks/kubevirt-web-ui/config.yml -e "apb_action=provision cluster=openshift registry_url=quay.io registry_namespace=kubevirt version=0.9.3" # for automatic tag association or :latest as default
+
+ansible-playbook -i your_inventory_file.ini playbooks/kubevirt-web-ui/config.yml -e "apb_action=deprovision cluster=openshift kubevirt_web_ui_image_name=whatever"
 ```
 

--- a/roles/kubevirt_web_ui/tasks/required_params.yml
+++ b/roles/kubevirt_web_ui/tasks/required_params.yml
@@ -1,9 +1,18 @@
 ---
-#### Verify required variables
+#### Verify/set kubevirt-web-ui image:tag
+
+- set_fact: kubevirt_web_ui_image_tag="v1.3.0"
+  when: version is defined and "0.9." in version
+
+- set_fact: kubevirt_web_ui_image_tag="v{{ docker_tag }}"
+  when: docker_tag is defined
+
+- set_fact: kubevirt_web_ui_image_name="{{ registry_url }}/{{ registry_namespace }}/kubevirt-web-ui:{{ kubevirt_web_ui_image_tag | default("latest")}}"
+  when: kubevirt_web_ui_image_name is not defined and registry_url is defined and registry_namespace is defined
 
 - name: Verify required kubevirt_web_ui_image_name variable is set
   fail:
-    msg: kubevirt_web_ui_image_name must be set to deploy kubevirt-web-ui
+    msg: kubevirt_web_ui_image_name must be set to deploy kubevirt-web-ui. Alternatively registry_url, registry_namespace and docker_tag (or version) can be used for automated composition.
   when: kubevirt_web_ui_image_name is not defined
 
 #### Autodiscovery of missing variables


### PR DESCRIPTION
The docker image:tag for kubevirt-web-ui can be either provided explicitly by
setting `kubevirt_web_ui_image_name` or
it can be newly determined automatically from the
`registry_url`, `registry_namespace`, `docker_tag` and `version`
variables, as they are supplied by `kubevirt-apb`.

**What this PR does**: support of kubevirt-apb provision flow without requiring any additional parameters

**Which issue(s) this PR fixes** *

**Special notes for your reviewer**:
So far just best-effort to verify via manual invocation of ansible-playbook by supplying various combinations of the registry_url, registry_namespace, docker_tag, version or kubevirt_web_ui_image_name.

Should be working from kubevirt-apb.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
