### PR TITLE
Fix platform variable determination

### DIFF
--- a/playbooks/kubevirt.yml
+++ b/playbooks/kubevirt.yml
@@ -5,14 +5,19 @@
   environment:
     http_proxy: ""
   tasks:
-    - name: Identify cluster
-      command: "oc get projects"
-      register: result
+    - name: Determine Environment
+      shell: "oc version> /dev/null 2>&1; if [ \"$?\" -eq 127 ]; then echo 'kubectl'; else echo 'oc'; fi"
+      register: cli
 
     - name: Set cluster variable
       set_fact:
         platform: "openshift"
-      when: "{{ result.rc }} == 0"
+      when: cli.stdout == "oc"
+
+    - name: Set cluster variable
+      set_fact:
+        platform: "kubernetes"
+      when: cli.stdout == "kubectl"
 
     - name: Login As Super User
       command: "oc login -u {{ admin_user }} -p {{ admin_password }}"

--- a/roles/kubevirt/tasks/provision.yml
+++ b/roles/kubevirt/tasks/provision.yml
@@ -18,6 +18,7 @@
 
 - name: Enable kubevirt feature gates
   shell: "oc apply -f {{ kubevirt_template_dir }}/kubevirt-config.yaml -n {{ namespace }}"
+  when: platform=="openshift"
 
 # Kubevirt manifest
 - name: Check for kubevirt.yaml.j2 template in {{ kubevirt_template_dir }}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The "oc get projects" task fails in upstream Kubernetes environment. We 
need to determine which environment is installed by another means. The new 
determination code was lifted from the cdi role.

Also any subsequent command to execute "oc" needs to be limited to the 
"openshift" platform.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubevirt/kubevirt-ansible/issues/458

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
