### PR TITLE
Fix kubevirt-web-ui for kubevirt-apb

### DIFF
--- a/playbooks/kubevirt-web-ui/private/config.yml
+++ b/playbooks/kubevirt-web-ui/private/config.yml
@@ -1,7 +1,7 @@
 ---
 - name: Kubevirt Web UI Install Checkpoint Start
   hosts: all
-  gather_facts: false
+  gather_facts: False
   tasks:
   - name: Set Console install 'In Progress'
     run_once: true
@@ -17,6 +17,7 @@
 - name: Kubevirt Web UI
   # hosts: oo_first_master
   hosts: masters[0]
+  gather_facts: False
   vars:
     first_master: "{{ masters[0] }}"
   tasks:
@@ -26,7 +27,7 @@
 
 - name: Kubevirt Web UI Install Checkpoint End
   hosts: all
-  gather_facts: false
+  gather_facts: False
   tasks:
   - name: Set Console install 'Complete'
     run_once: true

--- a/roles/kubevirt_web_ui/defaults/main.yml
+++ b/roles/kubevirt_web_ui/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 openshift_client_binary: "oc"
 apb_action: "provision"
+kubevirt_web_ui_namespace: "kubevirt-web-ui"
 
 # Deviation from openshift-console: the kubevirt/web-ui is installed to an _existing_ openshift cluster,
 # so "defaultNodeSelector" (see master config) takes effect causing scheduler to find no "master and compute" node.

--- a/roles/kubevirt_web_ui/tasks/deprovision.yml
+++ b/roles/kubevirt_web_ui/tasks/deprovision.yml
@@ -1,6 +1,6 @@
 ---
 - name: Remove kubevirt-web-ui project
-  shell: "{{ openshift_client_binary }} delete project kubevirt-web-ui"
+  shell: "{{ openshift_client_binary }} delete project {{ kubevirt_web_ui_namespace }}"
 
 - name: Remove Kubevirt Web UI OAuth client
   shell: "{{ openshift_client_binary }} delete oauthclient kubevirt-web-ui"

--- a/roles/kubevirt_web_ui/tasks/provision.yml
+++ b/roles/kubevirt_web_ui/tasks/provision.yml
@@ -1,11 +1,11 @@
 ---
-- name: Check if kubevirt-web-ui project exists
-  shell: "{{ openshift_client_binary }} projects -q | grep -w kubevirt-web-ui | awk '{ print $1 }'"
+- name: Check if project for kubevirt-web-ui exists
+  shell: "{{ openshift_client_binary }} projects -q | grep -w {{ kubevirt_web_ui_namespace }} | awk '{ print $1 }'"
   register: ns
 
 - name: Create kubevirt-web-ui project
-  shell: "{{ openshift_client_binary }} new-project kubevirt-web-ui"
-  when: ns.stdout != "kubevirt-web-ui"
+  shell: "{{ openshift_client_binary }} new-project {{ kubevirt_web_ui_namespace }}"
+  when: ns.stdout == ""
 
 - name: Make temp directory for console templates
   command: mktemp -d /tmp/console-ansible-XXXXXX
@@ -25,7 +25,7 @@
 # contents so we don't overwrite changes.
 
 - name: Read the existing console config map
-  shell: "{{ openshift_client_binary }} get configmap console-config -n kubevirt-web-ui -o jsonpath='{.data}' | true"
+  shell: "{{ openshift_client_binary }} get configmap console-config -n {{ kubevirt_web_ui_namespace }} -o jsonpath='{.data}' | true"
   register: console_config_map
 
 - set_fact:
@@ -65,6 +65,7 @@
   shell: >
     {{ openshift_client_binary }} process -f "{{ mktemp.stdout }}/{{ __console_template_file }}"
     --param IMAGE="{{ kubevirt_web_ui_image_name }}"
+    --param NAMESPACE="{{ kubevirt_web_ui_namespace }}"
     --param NODE_SELECTOR={{ kubevirt_web_ui_nodeselector | to_json | quote }}
     --param SERVER_CONFIG="{{ updated_console_config['content'] | b64decode }}"
     --param REPLICA_COUNT="{{ kubevirt_web_ui_replica_count }}"

--- a/roles/kubevirt_web_ui/tasks/provision.yml
+++ b/roles/kubevirt_web_ui/tasks/provision.yml
@@ -12,12 +12,6 @@
   register: mktemp
   changed_when: False
 
-- name: Copy admin client config
-  command: >
-    cp {{ openshift.common.config_base }}/master/admin.kubeconfig {{ mktemp.stdout }}/admin.kubeconfig
-  become: true
-  changed_when: false
-
 - name: Copy console templates to temp directory
   copy:
     src: "{{ item }}"
@@ -68,7 +62,6 @@
   register: updated_console_config
 
 - name: Apply the console template file
-  become: true
   shell: >
     {{ openshift_client_binary }} process -f "{{ mktemp.stdout }}/{{ __console_template_file }}"
     --param IMAGE="{{ kubevirt_web_ui_image_name }}"
@@ -79,8 +72,7 @@
     --param TLS_CERT="{{ console_cert | default('') }}"
     --param TLS_KEY="{{ console_key | default('') }}"
     --param TLS_CA_CERT="{{ console_ca_cert | default('') }}"
-    --config={{ mktemp.stdout }}/admin.kubeconfig
-    | {{ openshift_client_binary }} apply --config={{ mktemp.stdout }}/admin.kubeconfig -f -
+    | {{ openshift_client_binary }} apply -f -
 
 - name: Remove temp directory
   file:

--- a/roles/kubevirt_web_ui/tasks/start.yml
+++ b/roles/kubevirt_web_ui/tasks/start.yml
@@ -4,8 +4,7 @@
   # A zero return code indicates the rollout succeeded.
   # https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#complete-deployment
   command: >
-    {{ openshift_client_binary }} rollout status deployment/console --config={{ openshift.common.config_base }}/master/admin.kubeconfig -n kubevirt-web-ui
+    {{ openshift_client_binary }} rollout status deployment/console -n kubevirt-web-ui
   changed_when: false
-  become: true
   # deviation from openshift-ansible: fail first and let the user gather troubleshooting info manually via `oc status`, `oc get pods`, `oc get events`, and `oc logs deployment/console`
 

--- a/roles/kubevirt_web_ui/tasks/start.yml
+++ b/roles/kubevirt_web_ui/tasks/start.yml
@@ -4,7 +4,7 @@
   # A zero return code indicates the rollout succeeded.
   # https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#complete-deployment
   command: >
-    {{ openshift_client_binary }} rollout status deployment/console -n kubevirt-web-ui
+    {{ openshift_client_binary }} rollout status deployment/console -n {{ kubevirt_web_ui_namespace }}
   changed_when: false
   # deviation from openshift-ansible: fail first and let the user gather troubleshooting info manually via `oc status`, `oc get pods`, `oc get events`, and `oc logs deployment/console`
 


### PR DESCRIPTION
**What this PR does** Adapts kubevirt-web-ui deployment for container (kubevirt-apb) environment:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Verified on fresh (today's) 3.11 OC in Upshift.

Unfortunately, I was not able to execute kubevirt-apb from UI, but mimicked on command-line:
```
docker run --rm -v $HOME/.kube:/opt/apb/.kube:z -u $UID \
  docker.io/mareklibra/kubevirt-apb:latest provision \
   --extra-vars '{"version":"0.9.3", "namespace":"kubevirt", "kubevirt_web_ui_namespace": "kubevirt-web-ui", "_apb_last_requesting_user":"admin", "_apb_plan_id":"default", "storage_role":"storage-none", "admin_user":"quicklab", "admin_password":"RedHat1!", "platform":"openshift", "docker_tag":"1.3", "registry_url":"brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888", "registry_namespace":"cnv-tech-preview"}'
```

The `docker.io/mareklibra/kubevirt-apb:latest` is built from kubevirt-apb master using this `mareklibra:web-ui.from.kubevirt-apb`.

Backport to release-0.9 follows.

**Release note**:
```release-note
NONE
```
