### PR TITLE
Set flaky CDI test in pending mode

### DIFF
--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Importing and starting a VM using CDI", func() {
 		})
 	})
 
-	Context("PVC with invalid image url", func() {
+	PContext("PVC with invalid image url", func() {
 		BeforeEach(func() {
 			newPVCName = pvcName1
 			url = invalidPVCURL


### PR DESCRIPTION
"PVC with invalid image url" test from e2e test is
failing even when the importer pod is failing.
The reason is that we try to assert that the pod is in Failed state,
while OC keep restarting it, so the status is Running.

Signed-off-by: gbenhaim <galbh2@gmail.com>
```release-note
None
```
