### PR TITLE
[VIRT] API change to v1alpha3

### DIFF
--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -14,7 +14,7 @@ const (
 	pvcName            = "golden-pvc"
 	pvcName1           = "golden-pvc1"
 	vmName             = "test-vm"
-	vmAPIVersion       = "kubevirt.io/v1alpha2"
+	vmAPIVersion       = "kubevirt.io/v1alpha3"
 	rawPVCFilePath     = "tests/manifests/golden-pvc.yml"
 	rawVMFilePath      = "tests/manifests/test-vm.yml"
 )

--- a/tests/high_performance_vm_test.go
+++ b/tests/high_performance_vm_test.go
@@ -26,7 +26,7 @@ var _ = Describe("High performance vm test", func() {
 		overcommitGuestOverheadStr = "Overcommit Guest Overhead:  true"
 		memoryOvercommit           = "true"
 		headless                   = "false"
-		vmAPIVersion               = "kubevirt.io/v1alpha2"
+		vmAPIVersion               = "kubevirt.io/v1alpha3"
 	)
 
 	flag.Parse()

--- a/tests/manifests/import-vm-v2v-apb.yml
+++ b/tests/manifests/import-vm-v2v-apb.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1
+apiVersion: kubevirt.io/v1alpha3
 kind: Template
 metadata:
   name: v2v-template

--- a/tests/manifests/test-vm.yml
+++ b/tests/manifests/test-vm.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1
+apiVersion: kubevirt.io/v1alpha3
 kind: Template
 metadata:
   creationTimestamp: null
@@ -17,12 +17,11 @@ objects:
           memory: 64M
       devices:
         disks:
-        - name: mydisk
-          volumeName: pvcvolume
+        - name: mydisk          
           disk:
             dev: vda
     volumes:
-      - name: pvcvolume
+      - name: mydisk
         persistentVolumeClaim:
           claimName: ${PVC_NAME}
 parameters:

--- a/tests/manifests/virt-testing-vm.yml
+++ b/tests/manifests/virt-testing-vm.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1
+apiVersion: kubevirt.io/v1alpha3
 kind: Template
 metadata:
   creationTimestamp: null
@@ -23,10 +23,9 @@ objects:
         disks:
         - disk:
             bus: virtio
-          name: registrydisk
-          volumeName: registryvolume
+          name: registrydisk          
     volumes:
-      - name: registryvolume
+      - name: registrydisk
         registryDisk:
           image: ${{IMAGE_NAME}}
 parameters:

--- a/tests/manifests/vm-cirros.yaml
+++ b/tests/manifests/vm-cirros.yaml
@@ -1,4 +1,4 @@
-apiVersion: kubevirt.io/v1alpha2
+apiVersion: kubevirt.io/v1alpha3
 kind: VirtualMachine
 metadata:
   creationTimestamp: null
@@ -18,12 +18,10 @@ spec:
           disks:
           - disk:
               bus: virtio
-            name: registrydisk
-            volumeName: registryvolume
+            name: registrydisk            
           - disk:
               bus: virtio
-            name: cloudinitdisk
-            volumeName: cloudinitvolume
+            name: cloudinitdisk            
         machine:
           type: ""
         resources:
@@ -31,7 +29,7 @@ spec:
             memory: 64M
       terminationGracePeriodSeconds: 0
       volumes:
-      - name: registryvolume
+      - name: registrydisk
         registryDisk:
           image: kubevirt/cirros-registry-disk-demo:latest
       - cloudInitNoCloud:
@@ -39,5 +37,5 @@ spec:
             #!/bin/sh
 
             echo 'printed from cloud-init userdata'
-        name: cloudinitvolume
+        name: cloudinitdisk
 status: {}

--- a/tests/manifests/vm_with_sidecar_hook.yml
+++ b/tests/manifests/vm_with_sidecar_hook.yml
@@ -1,4 +1,4 @@
-apiVersion: kubevirt.io/v1alpha2
+apiVersion: kubevirt.io/v1alpha3
 kind: VirtualMachineInstance
 metadata:
   annotations:
@@ -15,11 +15,9 @@ spec:
       - disk:
           bus: virtio
         name: registrydisk
-        volumeName: registryvolume
       - disk:
           bus: virtio
         name: cloudinitdisk
-        volumeName: cloudinitvolume
     machine:
       type: ""
     resources:
@@ -27,7 +25,7 @@ spec:
         memory: 1024M
   terminationGracePeriodSeconds: 0
   volumes:
-  - name: registryvolume
+  - name: registrydisk
     registryDisk:
       image: kubevirt/fedora-cloud-registry-disk-demo:latest
   - cloudInitNoCloud:
@@ -37,5 +35,5 @@ spec:
         chpasswd: { expire: False }
         bootcmd:          
           - "sudo dnf install dmidecode -y"
-    name: cloudinitvolume
+    name: cloudinitdisk
 status: {}

--- a/tests/manifests/vmi-ephemeral.yaml
+++ b/tests/manifests/vmi-ephemeral.yaml
@@ -1,4 +1,4 @@
-apiVersion: kubevirt.io/v1alpha2
+apiVersion: kubevirt.io/v1alpha3
 kind: VirtualMachineInstance
 metadata:
   creationTimestamp: null
@@ -11,8 +11,7 @@ spec:
       disks:
       - disk:
           bus: virtio
-        name: registrydisk
-        volumeName: registryvolume
+        name: registrydisk        
     machine:
       type: ""
     resources:
@@ -20,7 +19,7 @@ spec:
         memory: 64M
   terminationGracePeriodSeconds: 0
   volumes:
-  - name: registryvolume
+  - name: registrydisk
     registryDisk:
       image: kubevirt/cirros-registry-disk-demo:latest
 status: {}

--- a/tests/manifests/vmi-replicaset-cirros.yaml
+++ b/tests/manifests/vmi-replicaset-cirros.yaml
@@ -1,4 +1,4 @@
-apiVersion: kubevirt.io/v1alpha2
+apiVersion: kubevirt.io/v1alpha3
 kind: VirtualMachineInstanceReplicaSet
 metadata:
   creationTimestamp: null
@@ -20,7 +20,6 @@ spec:
           - disk:
               bus: virtio
             name: registrydisk
-            volumeName: registryvolume
         machine:
           type: ""
         resources:
@@ -28,7 +27,7 @@ spec:
             memory: 64M
       terminationGracePeriodSeconds: 0
       volumes:
-      - name: registryvolume
+      - name: registrydisk
         registryDisk:
           image: kubevirt/cirros-registry-disk-demo:latest
 status: {}


### PR DESCRIPTION
In the PR https://github.com/kubevirt/kubevirt/pull/1570
The Disks and Volumes need to have matching names, similar to Interfaces
and Networks. This makes the API more consistent.
I updated the test yaml files, and tests with the new structure.
