### PR TITLE
Add tests for, secrets and configmap as volumes

### DIFF
--- a/tests/framework/util.go
+++ b/tests/framework/util.go
@@ -1,11 +1,16 @@
 package framework
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"io/ioutil"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"golang.org/x/crypto/ssh"
 )
 
 func ProcessTemplateWithParameters(srcFilePath, dstFilePath string, params ...string) string {
@@ -47,4 +52,51 @@ func writeJson(jsonFile string, json string) (string, error) {
 func RunOcDescribeCommand(resourceType, resourceName string) string {
 	fmt.Printf("Getting 'oc describe' with: %s ", resourceName)
 	return execute(Result{cmd: "oc", verb: "describe", resourceType: resourceType, resourceName: resourceName, nameSpace: NamespaceTestDefault})
+}
+
+// generatePrivateKey creates a RSA Private Key of specified byte size
+func GeneratePrivateKey(bitSize int) (*rsa.PrivateKey, error) {
+	// Private Key generation
+	privateKey, err := rsa.GenerateKey(rand.Reader, bitSize)
+	if err != nil {
+		return nil, err
+	}
+
+	// Validate Private Key
+	err = privateKey.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	return privateKey, nil
+}
+
+// Will returns in the format "ssh-rsa ..."
+func GeneratePublicKey(privatekey *rsa.PublicKey) ([]byte, error) {
+	publicRsaKey, err := ssh.NewPublicKey(privatekey)
+	if err != nil {
+		return nil, err
+	}
+
+	publicKeyBytes := ssh.MarshalAuthorizedKey(publicRsaKey)
+
+	return publicKeyBytes, nil
+}
+
+// encodePrivateKeyToPEM encodes Private Key from RSA to PEM format
+func EncodePrivateKeyToPEM(privateKey *rsa.PrivateKey) []byte {
+	// Get ASN.1 DER format
+	privDER := x509.MarshalPKCS1PrivateKey(privateKey)
+
+	// pem.Block
+	privateBlock := pem.Block{
+		Type:    "RSA PRIVATE KEY",
+		Headers: nil,
+		Bytes:   privDER,
+	}
+
+	// Private key in PEM format
+	privatePEM := pem.EncodeToMemory(&privateBlock)
+
+	return privatePEM
 }

--- a/tests/secrets_and_cfgmap_test.go
+++ b/tests/secrets_and_cfgmap_test.go
@@ -1,0 +1,224 @@
+package tests_test
+
+import (
+	"flag"
+	"time"
+
+	expect "github.com/google/goexpect"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pborman/uuid"
+
+	tests "kubevirt.io/kubevirt-ansible/tests/framework"
+	"kubevirt.io/kubevirt/pkg/config"
+	"kubevirt.io/kubevirt/pkg/kubecli"
+	ktests "kubevirt.io/kubevirt/tests"
+)
+
+var _ = Describe("Config", func() {
+
+	flag.Parse()
+	virtClient, err := kubecli.GetKubevirtClient()
+	ktests.PanicOnError(err)
+
+	BeforeEach(func() {
+		ktests.BeforeTestCleanup()
+	})
+
+	Context("With a Secret and a ConfigMap defined", func() {
+
+		Context("With a single volume", func() {
+			var (
+				configMapName string
+				configMapPath string
+				secretName    string
+				secretPath    string
+			)
+
+			BeforeEach(func() {
+				configMapName = "configmap-" + uuid.NewRandom().String()
+				configMapPath = config.GetConfigMapSourcePath(configMapName + "-vol")
+				secretName = "secret-" + uuid.NewRandom().String()
+				secretPath = config.GetSecretSourcePath(secretName + "-vol")
+
+				config_data := map[string]string{
+					"config1": "value1",
+					"config2": "value2",
+					"config3": "value3",
+				}
+
+				secret_data := map[string]string{
+					"user":     "admin",
+					"password": "redhat",
+				}
+
+				ktests.CreateConfigMap(configMapName, config_data)
+
+				ktests.CreateSecret(secretName, secret_data)
+			})
+
+			AfterEach(func() {
+				ktests.DeleteConfigMap(configMapName)
+				ktests.DeleteSecret(secretName)
+			})
+
+			It("Should be that cfgMap and secret fs layout same for the pod and vmi", func() {
+				expectedOutput_cfgMap := "value1value2value3"
+				expectedOutput_Secret := "adminredhat"
+
+				By("Running VMI")
+
+				vmi := ktests.NewRandomVMIWithEphemeralDiskAndUserdataHighMemory(
+					ktests.RegistryDiskFor(
+						ktests.RegistryDiskFedora), "#!/bin/bash\necho \"fedora\" | passwd fedora --stdin\n")
+				ktests.AddConfigMapDisk(vmi, configMapName)
+				ktests.AddSecretDisk(vmi, secretName)
+				ktests.RunVMIAndExpectLaunch(vmi, false, 90)
+
+				By("Checking if ConfigMap has been attached to the pod")
+				vmiPod := ktests.GetRunningPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)
+				podOutput_cfgMap, err := ktests.ExecuteCommandOnPod(
+					virtClient,
+					vmiPod,
+					vmiPod.Spec.Containers[1].Name,
+					[]string{"cat",
+						configMapPath + "/config1",
+						configMapPath + "/config2",
+						configMapPath + "/config3",
+					},
+				)
+				Expect(err).To(BeNil())
+				Expect(podOutput_cfgMap).To(Equal(expectedOutput_cfgMap))
+
+				By("Checking mounted ConfigMap image")
+				expecter, err := tests.LoggedInFedoraExpecter(vmi.Name, tests.NamespaceTestDefault, 360)
+				Expect(err).ToNot(HaveOccurred())
+				defer expecter.Close()
+
+				_, err = expecter.ExpectBatch([]expect.Batcher{
+					// mount ConfigMap image
+					&expect.BSnd{S: "sudo su -\n"},
+					&expect.BExp{R: "#"},
+					&expect.BSnd{S: "mount /dev/sda /mnt\n"},
+					&expect.BSnd{S: "echo $?\n"},
+					&expect.BExp{R: "0"},
+					&expect.BSnd{S: "cat /mnt/config1 /mnt/config2 /mnt/config3\n"},
+					&expect.BExp{R: expectedOutput_cfgMap},
+				}, 200*time.Second)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Checking if Secret has also been attached to the same pod")
+				podOutput_Secret, err := ktests.ExecuteCommandOnPod(
+					virtClient,
+					vmiPod,
+					vmiPod.Spec.Containers[1].Name,
+					[]string{"cat",
+						secretPath + "/user",
+						secretPath + "/password",
+					},
+				)
+				Expect(err).To(BeNil())
+				Expect(podOutput_Secret).To(Equal(expectedOutput_Secret))
+
+				By("Checking mounted secret image")
+
+				_, err = expecter.ExpectBatch([]expect.Batcher{
+					// mount Secret image
+					&expect.BSnd{S: "mount /dev/sdb /mnt\n"},
+					&expect.BSnd{S: "echo $?\n"},
+					&expect.BExp{R: "0"},
+					&expect.BSnd{S: "cat /mnt/user /mnt/password\n"},
+					&expect.BExp{R: expectedOutput_Secret},
+				}, 200*time.Second)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+	})
+
+	Context("With SSH Keys as a Secret defined", func() {
+
+		Context("With a single volume", func() {
+			var (
+				secretName string
+				secretPath string
+			)
+
+			var bitSize int = 2048
+			privateKey, _ := tests.GeneratePrivateKey(bitSize)
+			publicKeyBytes, _ := tests.GeneratePublicKey(&privateKey.PublicKey)
+			privateKeyBytes := tests.EncodePrivateKeyToPEM(privateKey)
+
+			BeforeEach(func() {
+				secretName = "secret-" + uuid.NewRandom().String()
+				secretPath = config.GetSecretSourcePath(secretName + "-vol")
+
+				data := map[string]string{
+					"ssh-privatekey": string(privateKeyBytes),
+					"ssh-publickey":  string(publicKeyBytes),
+				}
+				ktests.CreateSecret(secretName, data)
+			})
+
+			AfterEach(func() {
+				ktests.DeleteSecret(secretName)
+			})
+
+			It("Should be the fs layout the same for a pod and vmi", func() {
+				expectedPrivateKey := string(privateKeyBytes)
+				expectedPublicKey := string(publicKeyBytes)
+
+				By("Running VMI")
+				vmi := ktests.NewRandomVMIWithEphemeralDiskAndUserdataHighMemory(
+					ktests.RegistryDiskFor(
+						ktests.RegistryDiskFedora), "#!/bin/bash\necho \"fedora\" | passwd fedora --stdin\n")
+				ktests.AddSecretDisk(vmi, secretName)
+				ktests.RunVMIAndExpectLaunch(vmi, false, 90)
+
+				By("Checking if Secret has been attached to the pod")
+				vmiPod := ktests.GetRunningPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)
+				podOutput1, err := ktests.ExecuteCommandOnPod(
+					virtClient,
+					vmiPod,
+					vmiPod.Spec.Containers[1].Name,
+					[]string{"cat",
+						secretPath + "/ssh-privatekey",
+					},
+				)
+				Expect(err).To(BeNil())
+				Expect(podOutput1).To(Equal(expectedPrivateKey))
+
+				podOutput2, err := ktests.ExecuteCommandOnPod(
+					virtClient,
+					vmiPod,
+					vmiPod.Spec.Containers[1].Name,
+					[]string{"cat",
+						secretPath + "/ssh-publickey",
+					},
+				)
+				Expect(err).To(BeNil())
+				Expect(podOutput2).To(Equal(expectedPublicKey))
+
+				By("Checking mounted secrets sshkeys image")
+				expecter, err := tests.LoggedInFedoraExpecter(vmi.Name, tests.NamespaceTestDefault, 360)
+				Expect(err).ToNot(HaveOccurred())
+				defer expecter.Close()
+
+				_, err = expecter.ExpectBatch([]expect.Batcher{
+					// mount iso Secret image
+					&expect.BSnd{S: "sudo su -\n"},
+					&expect.BExp{R: "#"},
+					&expect.BSnd{S: "mount /dev/sda /mnt\n"},
+					&expect.BSnd{S: "echo $?\n"},
+					&expect.BExp{R: "0"},
+					&expect.BSnd{S: "grep \"PRIVATE KEY\" /mnt/ssh-privatekey\n"},
+					&expect.BSnd{S: "echo $?\n"},
+					&expect.BExp{R: "0"},
+					&expect.BSnd{S: "grep ssh-rsa /mnt/ssh-publickey\n"},
+					&expect.BSnd{S: "echo $?\n"},
+					&expect.BExp{R: "0"},
+				}, 200*time.Second)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+	})
+})


### PR DESCRIPTION
1) Add test, configmap and secret as volumes on
   the same VM.

2) Add test, Secret with SSH Keys - Single Volume.

Signed-off-by: Kedar Bidarkar <kbidarka@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: Adds tests related to `secrets and configmap as volumes`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
1. I am aware of this PR, which does some major `framework` related changes, https://github.com/kubevirt/kubevirt-ansible/pull/473 . Will rebase this PR once PR 473 is merged.
2. `Add test, Secret with SSH Keys - Single Volume.`, this test did not pass for me locally, but still raising this PR for any review comments, that I can get, while working towards fixing it.

```
