### PR TITLE
Removed use of duplicate namespace in RunCommand function

### DIFF
--- a/tests/framework/cli_exec.go
+++ b/tests/framework/cli_exec.go
@@ -62,12 +62,12 @@ func executeWithCustomTimeout(r Result, timeout time.Duration) string {
 	}
 	if r.expectOut != "" {
 		Eventually(func() bool {
-			r.actualOut, _, err = ktests.RunCommand(r.cmd, cmd...)
+			r.actualOut, _, err = ktests.RunCommandWithNS(r.nameSpace, r.cmd, cmd...)
 			Expect(err).ToNot(HaveOccurred())
 			return strings.Contains(r.actualOut, r.expectOut)
 		}, timeout).Should(BeTrue(), fmt.Sprintf("Timed out waiting for %s to appear", r.resourceType))
 	} else {
-		r.actualOut, _, err = ktests.RunCommand(r.cmd, cmd...)
+		r.actualOut, _, err = ktests.RunCommandWithNS(r.nameSpace, r.cmd, cmd...)
 		Expect(err).ToNot(HaveOccurred())
 	}
 	return r.actualOut


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #489 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
