### PR TITLE
Add tests for, serviceAccount as volumes

### DIFF
--- a/tests/framework/util.go
+++ b/tests/framework/util.go
@@ -11,6 +11,10 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"golang.org/x/crypto/ssh"
+	k8sv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"kubevirt.io/kubevirt/pkg/kubecli"
+	ktests "kubevirt.io/kubevirt/tests"
 )
 
 func ProcessTemplateWithParameters(srcFilePath, dstFilePath string, params ...string) string {
@@ -99,4 +103,27 @@ func EncodePrivateKeyToPEM(privateKey *rsa.PrivateKey) []byte {
 	privatePEM := pem.EncodeToMemory(&privateBlock)
 
 	return privatePEM
+}
+
+func CreateServiceAccount(saName string) {
+	virtCli, err := kubecli.GetKubevirtClient()
+	ktests.PanicOnError(err)
+
+	sa := k8sv1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      saName,
+			Namespace: NamespaceTestDefault,
+		},
+	}
+
+	_, err = virtCli.CoreV1().ServiceAccounts(NamespaceTestDefault).Create(&sa)
+	Expect(err).ToNot(HaveOccurred())
+}
+
+func DeleteServiceAccount(saName string) {
+	virtCli, err := kubecli.GetKubevirtClient()
+	ktests.PanicOnError(err)
+
+	err = virtCli.CoreV1().ServiceAccounts(NamespaceTestDefault).Delete(saName, nil)
+	Expect(err).ToNot(HaveOccurred())
 }

--- a/tests/serviceaccount_test.go
+++ b/tests/serviceaccount_test.go
@@ -1,0 +1,118 @@
+package tests_test
+
+import (
+	"flag"
+	"time"
+
+	expect "github.com/google/goexpect"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pborman/uuid"
+
+	tests "kubevirt.io/kubevirt-ansible/tests/framework"
+	"kubevirt.io/kubevirt/pkg/config"
+	"kubevirt.io/kubevirt/pkg/kubecli"
+	ktests "kubevirt.io/kubevirt/tests"
+)
+
+var _ = Describe("Config", func() {
+
+	flag.Parse()
+	virtClient, err := kubecli.GetKubevirtClient()
+	ktests.PanicOnError(err)
+
+	BeforeEach(func() {
+		ktests.BeforeTestCleanup()
+	})
+
+	Context("With a non default ServiceAccount created", func() {
+
+		Context("With a single ServiceAccount created and attached", func() {
+			var (
+				serviceAccountName string
+				serviceAccountPath string
+			)
+
+			BeforeEach(func() {
+				serviceAccountName = "secret-" + uuid.NewRandom().String()
+				serviceAccountPath = config.ServiceAccountSourceDir
+
+				tests.CreateServiceAccount(serviceAccountName)
+			})
+
+			AfterEach(func() {
+				tests.DeleteServiceAccount(serviceAccountName)
+			})
+
+			It("Should be the fs layout the same for a pod and vmi", func() {
+				By("Running VMI")
+				vmi := ktests.NewRandomVMIWithEphemeralDiskAndUserdataHighMemory(
+					ktests.RegistryDiskFor(
+						ktests.RegistryDiskFedora), "#!/bin/bash\necho \"fedora\" | passwd fedora --stdin\n")
+				ktests.AddServiceAccountDisk(vmi, serviceAccountName)
+				ktests.RunVMIAndExpectLaunch(vmi, false, 90)
+
+				By("Checking if ServiceAccount has been attached to the pod")
+				vmiPod := ktests.GetRunningPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)
+				podOutput, err := ktests.ExecuteCommandOnPod(
+					virtClient,
+					vmiPod,
+					vmiPod.Spec.Containers[1].Name,
+					[]string{"cat",
+						serviceAccountPath + "/namespace",
+					},
+				)
+				Expect(err).To(BeNil())
+				Expect(podOutput).To(Equal(tests.NamespaceTestDefault))
+
+				By("Checking mounted serviceaccount image")
+				expecter, err := tests.LoggedInFedoraExpecter(vmi.Name, tests.NamespaceTestDefault, 360)
+				Expect(err).ToNot(HaveOccurred())
+				defer expecter.Close()
+
+				_, err = expecter.ExpectBatch([]expect.Batcher{
+					// mount iso Secret image
+					&expect.BSnd{S: "sudo su -\n"},
+					&expect.BExp{R: "#"},
+					&expect.BSnd{S: "mount /dev/sda /mnt\n"},
+					&expect.BSnd{S: "echo $?\n"},
+					&expect.BExp{R: "0"},
+					&expect.BSnd{S: "cat /mnt/namespace\n"},
+					&expect.BExp{R: tests.NamespaceTestDefault},
+				}, 200*time.Second)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("With two ServiceAccount created and attached", func() {
+			var (
+				serviceAccountName1 string
+				serviceAccountName2 string
+			)
+
+			BeforeEach(func() {
+				serviceAccountName1 = "secret1-" + uuid.NewRandom().String()
+				serviceAccountName2 = "secret2-" + uuid.NewRandom().String()
+
+				tests.CreateServiceAccount(serviceAccountName1)
+				tests.CreateServiceAccount(serviceAccountName2)
+			})
+
+			AfterEach(func() {
+				tests.DeleteServiceAccount(serviceAccountName1)
+				tests.DeleteServiceAccount(serviceAccountName2)
+			})
+
+			It("Should not run the vm with 2 service accounts", func() {
+				By("Ensuring VMI is not running")
+				vmi := ktests.NewRandomVMIWithEphemeralDiskAndUserdataHighMemory(
+					ktests.RegistryDiskFor(
+						ktests.RegistryDiskFedora), "#!/bin/bash\necho \"fedora\" | passwd fedora --stdin\n")
+				ktests.AddServiceAccountDisk(vmi, serviceAccountName1)
+				ktests.AddServiceAccountDisk(vmi, serviceAccountName2)
+				_, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
+				Expect(err).Should(HaveOccurred())
+			})
+		})
+	})
+})


### PR DESCRIPTION
1) Add test, non default serviceAccount on the VM.
2) Add test, 2 serviceAccount on the same VM should fail.

Signed-off-by: Kedar Bidarkar <kbidarka@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: Adds tests related to `serviceAccount as voume`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```NONE

```
