### PR TITLE
add common-templates test case - check Fedora booting process

### DIFF
--- a/tests/common_templates_test.go
+++ b/tests/common_templates_test.go
@@ -23,8 +23,6 @@ import (
 	"flag"
 	"os/exec"
 	"strings"
-	"net/http"
-	"io/ioutil"
 	"regexp"
 	"os"
 	"bufio"
@@ -33,6 +31,7 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+        framework "kubevirt.io/kubevirt-ansible/tests/framework"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/tests"
 )
@@ -43,8 +42,9 @@ var _ = Describe("Common templates", func() {
 	virtClient, err := kubecli.GetKubevirtClient()
 	tests.PanicOnError(err)
 
-	// Common templates read into string
-	var common_templates_yaml string
+	// Getting common_templates
+	// TODO2: replace downloading common-templates with getting common-templates from RPM
+	common_templates_yaml := string(framework.DownloadFile(framework.GetLatestGitHubReleaseURL("kubevirt", "common-templates")))
 
 	BeforeEach(func() {
 		tests.BeforeTestCleanup()
@@ -55,17 +55,7 @@ var _ = Describe("Common templates", func() {
 
 		// Applying datavolume
 		// TODO1: This is currently bugged and replaced with using vm.yaml. 
-		// exec.Command("/bin/bash", "-c", "/usr/bin/oc apply -f tests/manifests/fedora_datavolume.yaml")
-
-		// Getting common_templates
-		// TODO2: replace downloading common-templates with getting common-templates from RPM
-		ct_yml_url := "https://github.com/kubevirt/common-templates/releases/download/v0.3.1/common-templates-v0.3.1.yaml"
-		response, err := http.Get(ct_yml_url)
-		tests.PanicOnError(err)
-		defer response.Body.Close()
-		data, err := ioutil.ReadAll(response.Body)
-		common_templates_yaml = string(data)
-
+		// exec.Command("/bin/bash", "-c", "/usr/bin/oc apply -f tests/manifests/fedora_datavolume.yaml")		
 	})
 
 	Context("Test loading Fedora", func() {

--- a/tests/common_templates_test.go
+++ b/tests/common_templates_test.go
@@ -1,0 +1,167 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2018 Red Hat, Inc.
+ *
+ */
+
+package tests_test
+
+import (
+	"flag"
+	"os/exec"
+	"strings"
+	"net/http"
+	"io/ioutil"
+	"regexp"
+	"os"
+	"bufio"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"kubevirt.io/kubevirt/pkg/kubecli"
+	"kubevirt.io/kubevirt/tests"
+)
+
+var _ = Describe("Common templates", func() {
+	flag.Parse()
+
+	virtClient, err := kubecli.GetKubevirtClient()
+	tests.PanicOnError(err)
+
+	// Common templates read into string
+	var common_templates_yaml string
+
+	BeforeEach(func() {
+		tests.BeforeTestCleanup()
+
+		// Setting namespace
+		_, err := exec.Command("/bin/bash", "-c", "/usr/bin/oc project " + tests.NamespaceTestDefault).Output()
+		tests.PanicOnError(err)
+
+		// Applying datavolume
+		// TODO1: This is currently bugged and replaced with using vm.yaml. 
+		// exec.Command("/bin/bash", "-c", "/usr/bin/oc apply -f tests/manifests/fedora_datavolume.yaml")
+
+		// Getting common_templates
+		// TODO2: replace downloading common-templates with getting common-templates from RPM
+		ct_yml_url := "https://github.com/kubevirt/common-templates/releases/download/v0.3.1/common-templates-v0.3.1.yaml"
+		response, err := http.Get(ct_yml_url)
+		tests.PanicOnError(err)
+		defer response.Body.Close()
+		data, err := ioutil.ReadAll(response.Body)
+		common_templates_yaml = string(data)
+
+	})
+
+	Context("Test loading Fedora", func() {
+
+		// CNV-1065
+		It("Test loading Fedora", func() {
+
+			// Patterns needed for parsing common-templates.yaml
+			source_pattern, _ := regexp.Compile("# Source: dist/templates/(.*\\.yaml)\\s*")
+			os_pattern, _ := regexp.Compile("([^-]+)-[^-]+-[^-]+\\.yaml")
+
+			for _, yaml_segment := range strings.Split(common_templates_yaml, "\n---\n") {
+
+				lines := strings.Split(yaml_segment, "\n")
+				// Skip this yaml segment if it doesn't contain VM template
+				if (len(lines) == 0 || ! source_pattern.MatchString(lines[0])) {
+					continue
+				}
+
+				filename := source_pattern.FindStringSubmatch(lines[0])[1]
+				os_name := os_pattern.FindStringSubmatch(filename)[1]
+				// Skip this template if it is not Fedora
+				if (os_name != "fedora") {
+					continue
+				}
+
+				By("Reading " + filename)
+				// Write data to a file and feed this file to oc process
+				// TODO2: replace downloading common-templates with getting common-templates from RPM
+				// Currently this core is commented and the workaround is used
+				//out, err := os.Create("_out/" + filename)
+				//Expect(err).ToNot(HaveOccurred())
+				//out.WriteString(yaml_segment)
+				//out.Close()
+				//volume_name := "fedora-dv"
+				// command := "/usr/bin/oc process --local"
+				// command += " -f _out/" + filename
+				// command += " PVCNAME=" + volume_name
+				// command += " NAME=common-templates-test-vm"
+				// command += " | /usr/bin/oc apply -f -"
+				//output, _ := exec.Command("/bin/bash", "-c", ).Output()
+
+				// The workaround
+				_, err := exec.Command("/bin/bash", "-c", "/usr/bin/oc apply -f tests/manifests/vm.yaml").Output()
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Getting VM")
+				getVMOptions := metav1.GetOptions{}
+				vm, err := virtClient.VirtualMachine(tests.NamespaceTestDefault).Get("common-templates-test-vm", &getVMOptions)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Starting VM and checking that instance is created")
+				vm = tests.StartVirtualMachine(vm)
+				getOptions := metav1.GetOptions{}
+				_, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Get("common-templates-test-vm", &getOptions)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Checking that pod was created and has the right name")
+				listOptions := metav1.ListOptions{}
+				podList, err := virtClient.CoreV1().Pods(tests.NamespaceTestDefault).List(listOptions)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(podList.Items).To(HaveLen(1), "Exactly 1 pod should exist")
+				Expect(podList.Items[0].Name).To(HavePrefix("virt-launcher-common-templates-test-vm"), "Pod's name should contain name of the VM associated with it")
+
+				By("Checking output of VMI console")
+				cmd := exec.Command("/usr/bin/virtctl", "console", "common-templates-test-vm")
+				stdout, err := cmd.StdoutPipe()
+				Expect(err).ToNot(HaveOccurred())
+				// TODO3: passing stdin as an input because virtctl console require input object to be terminal
+				// This later leads to problem with output, but at the moment I don't know how to avoid it
+				cmd.Stdin = os.Stdin
+				err = cmd.Start()
+				Expect(err).ToNot(HaveOccurred())
+				scanner := bufio.NewScanner(stdout)
+				// We consider VM started successfully if we see these 2 lines one after another
+				os_version_pattern, _ := regexp.Compile("^Fedora \\d{2} \\(Cloud Edition\\)")
+				kernel_version, _ := regexp.Compile("^Kernel [a-z\\d\\.\\-_]+ on an x86_64 \\(ttyS0\\)")
+				os_welcome_found := false
+				for scanner.Scan() {
+					text := scanner.Text()
+					if (os_version_pattern.MatchString(text)) {
+						scanner.Scan()
+						text = scanner.Text()
+						if (kernel_version.MatchString(text)) {
+							os_welcome_found = true
+							break
+						}
+					}
+				}
+				Expect(os_welcome_found).To(BeTrue(), "VM console booting output should reach welcoming lines")
+				//err = cmd.Process.Kill()
+				//Expect(err).ToNot(HaveOccurred())
+				//err = cmd.Wait()
+				//Expect(err).ToNot(HaveOccurred())
+			}
+		})
+	})
+})
+

--- a/tests/common_templates_test.go
+++ b/tests/common_templates_test.go
@@ -109,7 +109,7 @@ var _ = Describe("Common templates", func() {
 				//output, _ := exec.Command("/bin/bash", "-c", ).Output()
 
 				// The workaround
-				_, err := exec.Command("/bin/bash", "-c", "/usr/bin/oc apply -f tests/manifests/vm.yaml").Output()
+				_, err := exec.Command("/bin/bash", "-c", "/usr/bin/oc apply -f tests/manifests/vm-fedora-workaround.yaml").Output()
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Getting VM")

--- a/tests/manifests/fedora_datavolume.yaml
+++ b/tests/manifests/fedora_datavolume.yaml
@@ -1,0 +1,15 @@
+apiVersion: cdi.kubevirt.io/v1alpha1
+kind: DataVolume
+metadata:
+  name: "fedora-dv"
+spec:
+  source:
+      http:
+         url: "https://download.fedoraproject.org/pub/fedora/linux/releases/29/Cloud/x86_64/images/Fedora-Cloud-Base-29-1.2.x86_64.qcow2" 
+         secretRef: ""
+  pvc:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: "1G"

--- a/tests/manifests/vm-cirros.yaml
+++ b/tests/manifests/vm-cirros.yaml
@@ -28,12 +28,14 @@ spec:
           type: ""
         resources:
           requests:
-            memory: 64M
+#            memory: 64M
+            memory: 2024M
       terminationGracePeriodSeconds: 0
       volumes:
       - name: registryvolume
         registryDisk:
-          image: kubevirt/cirros-registry-disk-demo:latest
+#          image: kubevirt/cirros-registry-disk-demo:latest
+          image: kubevirt/fedora-cloud-registry-disk-demo:latest
       - cloudInitNoCloud:
           userData: |
             #!/bin/sh

--- a/tests/manifests/vm-cirros.yaml
+++ b/tests/manifests/vm-cirros.yaml
@@ -28,14 +28,12 @@ spec:
           type: ""
         resources:
           requests:
-#            memory: 64M
-            memory: 2024M
+            memory: 64M
       terminationGracePeriodSeconds: 0
       volumes:
       - name: registryvolume
         registryDisk:
-#          image: kubevirt/cirros-registry-disk-demo:latest
-          image: kubevirt/fedora-cloud-registry-disk-demo:latest
+          image: kubevirt/cirros-registry-disk-demo:latest
       - cloudInitNoCloud:
           userData: |
             #!/bin/sh

--- a/tests/manifests/vm-fedora-workaround.yaml
+++ b/tests/manifests/vm-fedora-workaround.yaml
@@ -1,0 +1,42 @@
+apiVersion: kubevirt.io/v1alpha2
+kind: VirtualMachine
+metadata:
+  creationTimestamp: null
+  labels:
+    kubevirt.io/vm: common-templates-test-vm
+  name: common-templates-test-vm
+spec:
+  running: false
+  template:
+    metadata:
+      labels:
+        kubevirt.io/vm: common-templates-test-vm
+    spec:
+      domain:
+        devices:
+          disks:
+          - disk:
+              bus: virtio
+            name: registrydisk
+            volumeName: registryvolume
+          - disk:
+              bus: virtio
+            name: cloudinitdisk
+            volumeName: cloudinitvolume
+        machine:
+          type: ""
+        resources:
+          requests:
+            memory: 2024M
+      terminationGracePeriodSeconds: 0
+      volumes:
+      - name: registryvolume
+        registryDisk:
+          image: kubevirt/fedora-cloud-registry-disk-demo:latest
+      - cloudInitNoCloud:
+          userData: |
+            #!/bin/sh
+
+            echo 'printed from cloud-init userdata'
+        name: cloudinitvolume
+status: {}


### PR DESCRIPTION
**What this PR does / why we need it**:

This test case implements checking booting process of Fedora system in the case of using common-templates.

**Special notes for your reviewer**:

1) Due to possible bug in openshift/kubevirt (https://github.com/kubevirt/kubevirt/issues/1316
) I can't start virtual machine created from template. So, creation from template is currently replaced by creating from VM yaml (using disk image registry) in order to make the whole test work. The code that uses templates is already written, but commented out.
2) downloading instead of RPM @MarSik said me that I have to use template file installed from rpm. But latest rpm file N/A to download it by everyone who can download and run this test. By this reason I download it. Will be fixed later. 
3) terminal problem. Passing stdin as an input because virtctl console require input object to be terminal. This later leads to problem with output, but at the moment I don't know how to avoid it.
If anybody knows, please suggest a patch.
