### PR TITLE
revert pending case in node eviction

### DIFF
--- a/tests/framework/types.go
+++ b/tests/framework/types.go
@@ -39,22 +39,22 @@ type VirtualMachine struct {
 
 func (vm VirtualMachine) Create() (string, string, error) {
 	args := []string{"create", "-f", vm.Manifest}
-	return ktests.RunCommandWithNS(vm.Namespace, ktests.KubeVirtOcPath, args...)
+	return ktests.RunCommandWithNS(vm.Namespace, "oc", args...)
 }
 
 func (vm VirtualMachine) Start() (string, string, error) {
 	args := []string{"start", vm.Name}
-	return ktests.RunCommandWithNS(vm.Namespace, ktests.KubeVirtVirtctlPath, args...)
+	return ktests.RunCommandWithNS(vm.Namespace, "virtctl", args...)
 }
 
 func (vm VirtualMachine) Stop() (string, string, error) {
 	args := []string{"stop", vm.Name}
-	return ktests.RunCommandWithNS(vm.Namespace, ktests.KubeVirtVirtctlPath, args...)
+	return ktests.RunCommandWithNS(vm.Namespace, "virtctl", args...)
 }
 
 func (vm VirtualMachine) Delete() (string, string, error) {
 	args := []string{"delete", vm.Type, vm.Name}
-	return ktests.RunCommandWithNS(vm.Namespace, ktests.KubeVirtVirtctlPath, args...)
+	return ktests.RunCommandWithNS(vm.Namespace, "virtctl", args...)
 }
 
 func (vm VirtualMachine) IsRunning() (bool, error) {
@@ -73,7 +73,7 @@ func (vm VirtualMachine) IsRunning() (bool, error) {
 
 func (vm VirtualMachine) GetVMInfo(spec string) (string, string, error) {
 	args := []string{"get", vm.Type, vm.Name, "--template", spec}
-	return ktests.RunCommandWithNS(vm.Namespace, ktests.KubeVirtOcPath, args...)
+	return ktests.RunCommandWithNS(vm.Namespace, "oc", args...)
 }
 
 func (vm VirtualMachine) GetVMUID() (string, error) {
@@ -100,7 +100,7 @@ func (vm VirtualMachine) ProcessTemplate() (string, error) {
 
 	args = append(args, vm.TemplateParams...)
 
-	output, cmderr, err := ktests.RunCommandWithNS(NamespaceTestTemplate, ktests.KubeVirtOcPath, args...)
+	output, cmderr, err := ktests.RunCommandWithNS(NamespaceTestTemplate, "oc", args...)
 	if err != nil {
 		return "", err
 	}

--- a/tests/framework/types.go
+++ b/tests/framework/types.go
@@ -59,11 +59,11 @@ func (vm VirtualMachine) Delete() (string, string, error) {
 
 func (vm VirtualMachine) IsRunning() (bool, error) {
 	output, cmderr, err := vm.GetVMInfo("{{.status.phase}}")
-	if err != nil {
-		return false, err
-	}
 	if cmderr != "" {
 		return false, errors.New(cmderr)
+	}
+	if err != nil {
+		return false, err
 	}
 	if output == "Running" {
 		return true, nil
@@ -78,11 +78,11 @@ func (vm VirtualMachine) GetVMInfo(spec string) (string, string, error) {
 
 func (vm VirtualMachine) GetVMUID() (string, error) {
 	output, cmderr, err := vm.GetVMInfo("{{.metadata.uid}}")
-	if err != nil {
-		return "", err
-	}
 	if cmderr != "" {
 		return "", errors.New(cmderr)
+	}
+	if err != nil {
+		return "", err
 	}
 	vm.UID = output
 	return output, nil
@@ -101,11 +101,11 @@ func (vm VirtualMachine) ProcessTemplate() (string, error) {
 	args = append(args, vm.TemplateParams...)
 
 	output, cmderr, err := ktests.RunCommandWithNS(NamespaceTestTemplate, "oc", args...)
-	if err != nil {
-		return "", err
-	}
 	if cmderr != "" {
 		return "", errors.New(cmderr)
+	}
+	if err != nil {
+		return "", err
 	}
 	// TODO：if the image is pullable naturally, will remove the string replacement.
 	if strings.Contains(output, "registry:5000/") {

--- a/tests/framework/types.go
+++ b/tests/framework/types.go
@@ -37,31 +37,56 @@ type VirtualMachine struct {
 	Namespace         string
 }
 
-func (vm VirtualMachine) Create() (string, string, error) {
+func (vm VirtualMachine) Create() (string, error) {
 	args := []string{"create", "-f", vm.Manifest}
-	return ktests.RunCommandWithNS(vm.Namespace, "oc", args...)
+	output, stderr, err := ktests.RunCommandWithNS(vm.Namespace, "oc", args...)
+	if stderr != "" {
+		return "", errors.New(stderr)
+	}
+	if err != nil {
+		return "", err
+	}
+	return output, nil
 }
 
-func (vm VirtualMachine) Start() (string, string, error) {
+func (vm VirtualMachine) Start() (string, error) {
 	args := []string{"start", vm.Name}
-	return ktests.RunCommandWithNS(vm.Namespace, "virtctl", args...)
+	output, stderr, err := ktests.RunCommandWithNS(vm.Namespace, "virtctl", args...)
+	if stderr != "" {
+		return "", errors.New(stderr)
+	}
+	if err != nil {
+		return "", err
+	}
+	return output, nil
 }
 
-func (vm VirtualMachine) Stop() (string, string, error) {
+func (vm VirtualMachine) Stop() (string, error) {
 	args := []string{"stop", vm.Name}
-	return ktests.RunCommandWithNS(vm.Namespace, "virtctl", args...)
+	output, stderr, err := ktests.RunCommandWithNS(vm.Namespace, "virtctl", args...)
+	if stderr != "" {
+		return "", errors.New(stderr)
+	}
+	if err != nil {
+		return "", err
+	}
+	return output, nil
 }
 
-func (vm VirtualMachine) Delete() (string, string, error) {
+func (vm VirtualMachine) Delete() (string, error) {
 	args := []string{"delete", vm.Type, vm.Name}
-	return ktests.RunCommandWithNS(vm.Namespace, "virtctl", args...)
+	output, stderr, err := ktests.RunCommandWithNS(vm.Namespace, "oc", args...)
+	if stderr != "" {
+		return "", errors.New(stderr)
+	}
+	if err != nil {
+		return "", err
+	}
+	return output, nil
 }
 
 func (vm VirtualMachine) IsRunning() (bool, error) {
-	output, cmderr, err := vm.GetVMInfo("{{.status.phase}}")
-	if cmderr != "" {
-		return false, errors.New(cmderr)
-	}
+	output, err := vm.GetVMInfo("{{.status.phase}}")
 	if err != nil {
 		return false, err
 	}
@@ -71,16 +96,20 @@ func (vm VirtualMachine) IsRunning() (bool, error) {
 	return false, nil
 }
 
-func (vm VirtualMachine) GetVMInfo(spec string) (string, string, error) {
+func (vm VirtualMachine) GetVMInfo(spec string) (string, error) {
 	args := []string{"get", vm.Type, vm.Name, "--template", spec}
-	return ktests.RunCommandWithNS(vm.Namespace, "oc", args...)
+	output, stderr, err := ktests.RunCommandWithNS(vm.Namespace, "oc", args...)
+	if stderr != "" {
+		return "", errors.New(stderr)
+	}
+	if err != nil {
+		return "", err
+	}
+	return output, nil
 }
 
 func (vm VirtualMachine) GetVMUID() (string, error) {
-	output, cmderr, err := vm.GetVMInfo("{{.metadata.uid}}")
-	if cmderr != "" {
-		return "", errors.New(cmderr)
-	}
+	output, err := vm.GetVMInfo("{{.metadata.uid}}")
 	if err != nil {
 		return "", err
 	}

--- a/tests/node_eviction_test.go
+++ b/tests/node_eviction_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Node Eviction", func() {
 		})
 		It("virtualmachine instance will not be re-scheduled", func() {
 			By("Create the virtualmachine instance")
-			_, _, err := vmi.Create()
+			_, err := vmi.Create()
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Check that the virtualmachine instance is running")
@@ -63,7 +63,7 @@ var _ = Describe("Node Eviction", func() {
 			}, time.Minute*10).Should(BeTrue())
 
 			By("Retrieve the vmi's node")
-			nodeName, _, err := vmi.GetVMInfo("{{.status.nodeName}}")
+			nodeName, err := vmi.GetVMInfo("{{.status.nodeName}}")
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Drain the vmi's node")
@@ -72,7 +72,7 @@ var _ = Describe("Node Eviction", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Verify that the virtual machine instance is Failed")
-			output, _, err := vmi.GetVMInfo("{{.status.phase}}")
+			output, err := vmi.GetVMInfo("{{.status.phase}}")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(output).To(Equal("Failed"))
 
@@ -103,7 +103,7 @@ var _ = Describe("Node Eviction", func() {
 		})
 		It("virtualmachineinstance owned by a replicaset will be re-scheduled", func() {
 			By("Create the virtualmachine instance replicaset")
-			_, _, err := vmi.Create()
+			_, err := vmi.Create()
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Check that the virtualmachine instance is running")
@@ -122,7 +122,7 @@ var _ = Describe("Node Eviction", func() {
 			}
 
 			By("Retrieve the vmi's node")
-			nodeName, _, err := vmi.GetVMInfo("{{.status.nodeName}}")
+			nodeName, err := vmi.GetVMInfo("{{.status.nodeName}}")
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Drain the vmi's node")
@@ -152,7 +152,7 @@ var _ = Describe("Node Eviction", func() {
 					return output
 				}, time.Minute*2).Should(BeTrue())
 
-				output, _, err := vmi.GetVMInfo("{{.status.nodeName}}")
+				output, err := vmi.GetVMInfo("{{.status.nodeName}}")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(output).ToNot(Equal(nodeName))
 			}
@@ -178,11 +178,11 @@ var _ = Describe("Node Eviction", func() {
 		})
 		It("virtualmachineinstance owned by a virtual machine will be re-scheduled", func() {
 			By("Create the virtualmachine instance's vm")
-			_, _, err := vmi.Create()
+			_, err := vmi.Create()
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Start the virtual machine via virtctl")
-			_, _, err = vmi.Start()
+			_, err = vmi.Start()
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Check that the virtualmachine instance is running")
@@ -193,7 +193,7 @@ var _ = Describe("Node Eviction", func() {
 			}, time.Minute*10).Should(BeTrue())
 
 			By("Retrieve the vmi's node")
-			nodeName, _, err := vmi.GetVMInfo("{{.status.nodeName}}")
+			nodeName, err := vmi.GetVMInfo("{{.status.nodeName}}")
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Drain the vmi's node")


### PR DESCRIPTION
 - revert the pending case
 - refactor test steps by call VM methods
 - revert ktests.KubeVirtOcPath to oc

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Use `ktests.KubeVirtOcPath` in `RunCommand` or `RunCommandWithNS` is not working because `CreateCommandWithNS` only recognize `oc`, `virtctl` and `kubectl`, so revert it.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
