### PR TITLE
adding missing apb params

### DIFF
--- a/roles/network-multus/defaults/main.yml
+++ b/roles/network-multus/defaults/main.yml
@@ -2,6 +2,10 @@ namespace: "kube-system"
 cluster: "openshift"
 apb_action: "provision"
 
+registry_url: "registry.access.redhat.com"
+registry_namespace: "cnv-tech-preview"
+docker_tag: "v1.3.0"
+
 multus_provisioner_name: "kube-multus-amd64"
 multus_provisioner_repo: "docker.io/nfvpe/multus"
 multus_provisioner_release: "latest"

--- a/roles/network-multus/defaults/main.yml
+++ b/roles/network-multus/defaults/main.yml
@@ -2,9 +2,9 @@ namespace: "kube-system"
 cluster: "openshift"
 apb_action: "provision"
 
-registry_url: "registry.access.redhat.com"
-registry_namespace: "cnv-tech-preview"
-docker_tag: "v1.3.0"
+registry_url: "docker.io"
+registry_namespace: "kubevirt"
+docker_tag: "v0.9.6"
 
 multus_provisioner_name: "kube-multus-amd64"
 multus_provisioner_repo: "docker.io/nfvpe/multus"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

When creating a ServiceInstance and running the APB the following error occurs:
...
TASK [network-multus : Render multus deployment yaml] **************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'registry_url' is undefined"}
...

apiVersion: servicecatalog.k8s.io/v1beta1
kind: ServiceInstance
metadata:
  name: kubevirt
  namespace: kube-system
spec:
  clusterServiceClassExternalName: localregistry-virtualization
  clusterServicePlanExternalName: default
  parameters:
    admin_user: admin
    admin_password: ...OUTPUT...

Besides registry_url, docker_tag and registry_namespace are also required.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
