### PR TITLE
Run SR-IOV DP configuration play before detecting client nodes

### DIFF
--- a/playbooks/kubevirt.yml
+++ b/playbooks/kubevirt.yml
@@ -1,25 +1,9 @@
+# note: the order of plays in the playbook is important: the first play that
+# configures SR-IOV device plugin should be executed before the play that
+# identifies nodes with configured OpenShift client, otherwise the SR-IOV play
+# won't be executed for nodes that would fail on calling 'oc get projects' just
+# because they have client mis- or unconfigured.
 ---
-- hosts: all
-  connection: local
-  gather_facts: False
-  environment:
-    http_proxy: ""
-  tasks:
-    - name: Identify cluster
-      command: "oc get projects"
-      register: result
-
-    - name: Set cluster variable
-      set_fact:
-        platform: "openshift"
-      when: "{{ result.rc }} == 0"
-
-    - name: Login As Super User
-      command: "oc login -u {{ admin_user }} -p {{ admin_password }}"
-      when: platform == "openshift"
-            and admin_user is defined
-            and admin_password is defined
-
 # note: strictly speaking, we should avoid configuring sriovdp when
 # deploy_sriov_plugin is disabled but the fact is not defined on this level so
 # instead we fall back to deploying configuration file on all nodes. This
@@ -41,6 +25,27 @@
           dest: /etc/pcidp/config.json
         become: yes
       when: network_role == 'network-multus'
+
+- hosts: all
+  connection: local
+  gather_facts: False
+  environment:
+    http_proxy: ""
+  tasks:
+    - name: Identify cluster
+      command: "oc get projects"
+      register: result
+
+    - name: Set cluster variable
+      set_fact:
+        platform: "openshift"
+      when: "{{ result.rc }} == 0"
+
+    - name: Login As Super User
+      command: "oc login -u {{ admin_user }} -p {{ admin_password }}"
+      when: platform == "openshift"
+            and admin_user is defined
+            and admin_password is defined
 
 - hosts: masters[0]
   connection: local


### PR DESCRIPTION
We should configure SR-IOV device plugin on all cluster nodes regardless
whether they have OpenShift client configured. This patch moves the
SR-IOV DP configuration section before the client detection section, so
that even if the latter fails for a node, the node still gets configured
for SR-IOV DP scheduling, if that happens.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #516

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
