### PR TITLE
Rename all references of reigstrydisk to containerdisk

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -5,7 +5,7 @@ import:
 - package: github.com/onsi/gomega
   version: dcabb60a477c2b6f456df65037cb6708210fbb02
 - package: kubevirt.io/kubevirt
-  version: v0.9.6
+  version: v0.12.0-alpha.2
   repo:    https://github.com/kubevirt/kubevirt.git
 - package: kubevirt.io/qe-tools
   version: v0.1.2

--- a/glide.yaml
+++ b/glide.yaml
@@ -5,7 +5,7 @@ import:
 - package: github.com/onsi/gomega
   version: dcabb60a477c2b6f456df65037cb6708210fbb02
 - package: kubevirt.io/kubevirt
-  version: v0.12.0-alpha.2
+  version: v0.9.6
   repo:    https://github.com/kubevirt/kubevirt.git
 - package: kubevirt.io/qe-tools
   version: v0.1.2

--- a/tests/high_performance_vm_test.go
+++ b/tests/high_performance_vm_test.go
@@ -32,7 +32,7 @@ var _ = Describe("High performance vm test", func() {
 
 	flag.Parse()
 	virtClient, err := kubecli.GetKubevirtClient()
-	registryDisk := ktests.RegistryDiskFor(ktests.RegistryDiskCirros)
+	containerDisk := ktests.ContainerDiskFor(ktests.ContainerDiskCirros)
 	ktests.PanicOnError(err)
 
 	ktests.BeforeAll(func() {
@@ -44,7 +44,7 @@ var _ = Describe("High performance vm test", func() {
 		headlesstestVMName := "headlesstest"
 
 		It("Create headless VM", func() {
-			tests.ProcessTemplateWithParameters(virtRawVMFilePath, headlessDstVMFilePath, "VM_NAME="+headlesstestVMName, "AUTO_GRAPHIC_DEVICE="+headless, "IMAGE_NAME="+registryDisk, "VM_APIVERSION="+vmAPIVersion)
+			tests.ProcessTemplateWithParameters(virtRawVMFilePath, headlessDstVMFilePath, "VM_NAME="+headlesstestVMName, "AUTO_GRAPHIC_DEVICE="+headless, "IMAGE_NAME="+containerDisk, "VM_APIVERSION="+vmAPIVersion)
 			tests.CreateResourceWithFilePathTestNamespace(headlessDstVMFilePath)
 			tests.WaitUntilResourceReadyByNameTestNamespace("vmi", headlesstestVMName, "-o=jsonpath='{.status.phase}'", "Running")
 		})
@@ -64,7 +64,7 @@ var _ = Describe("High performance vm test", func() {
 		memoryOvercommitVMName := "memoryovercommit"
 
 		It("Create memoryOvercommit VM", func() {
-			tests.ProcessTemplateWithParameters(virtRawVMFilePath, memoryOvercommitDstVMFilePath, "VM_NAME="+memoryOvercommitVMName, "OVER_COMMIT_GUEST_OVERLOAD="+memoryOvercommit, "IMAGE_NAME="+registryDisk, "VM_APIVERSION="+vmAPIVersion)
+			tests.ProcessTemplateWithParameters(virtRawVMFilePath, memoryOvercommitDstVMFilePath, "VM_NAME="+memoryOvercommitVMName, "OVER_COMMIT_GUEST_OVERLOAD="+memoryOvercommit, "IMAGE_NAME="+containerDisk, "VM_APIVERSION="+vmAPIVersion)
 			tests.CreateResourceWithFilePathTestNamespace(memoryOvercommitDstVMFilePath)
 			tests.WaitUntilResourceReadyByNameTestNamespace("vmi", memoryOvercommitVMName, "-o=jsonpath='{.status.phase}'", "Running")
 		})
@@ -79,7 +79,7 @@ var _ = Describe("High performance vm test", func() {
 		memoryOvercommitVMName := "headlessandmemoryovercommit"
 
 		It("Create headless and memory over commit VM", func() {
-			tests.ProcessTemplateWithParameters(virtRawVMFilePath, memoryOvercommitDstVMFilePath, "VM_NAME="+memoryOvercommitVMName, "OVER_COMMIT_GUEST_OVERLOAD="+memoryOvercommit, "AUTO_GRAPHIC_DEVICE="+headless, "IMAGE_NAME="+registryDisk, "VM_APIVERSION="+vmAPIVersion)
+			tests.ProcessTemplateWithParameters(virtRawVMFilePath, memoryOvercommitDstVMFilePath, "VM_NAME="+memoryOvercommitVMName, "OVER_COMMIT_GUEST_OVERLOAD="+memoryOvercommit, "AUTO_GRAPHIC_DEVICE="+headless, "IMAGE_NAME="+containerDisk, "VM_APIVERSION="+vmAPIVersion)
 			tests.CreateResourceWithFilePathTestNamespace(memoryOvercommitDstVMFilePath)
 			tests.WaitUntilResourceReadyByNameTestNamespace("vmi", memoryOvercommitVMName, "-o=jsonpath='{.status.phase}'", "Running")
 		})

--- a/tests/manifests/virt-testing-vm.yml
+++ b/tests/manifests/virt-testing-vm.yml
@@ -23,11 +23,11 @@ objects:
         disks:
         - disk:
             bus: virtio
-          name: registrydisk
+          name: containerdisk
           volumeName: registryvolume
     volumes:
       - name: registryvolume
-        registryDisk:
+        containerDisk:
           image: ${{IMAGE_NAME}}
 parameters:
 - name: VM_APIVERSION

--- a/tests/manifests/vm-cirros.yaml
+++ b/tests/manifests/vm-cirros.yaml
@@ -18,7 +18,7 @@ spec:
           disks:
           - disk:
               bus: virtio
-            name: registrydisk
+            name: containerdisk
             volumeName: registryvolume
           - disk:
               bus: virtio
@@ -32,8 +32,8 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - name: registryvolume
-        registryDisk:
-          image: kubevirt/cirros-registry-disk-demo:latest
+        containerDisk:
+          image: kubevirt/cirros-container-disk-demo:latest
       - cloudInitNoCloud:
           userData: |
             #!/bin/sh

--- a/tests/manifests/vm_with_sidecar_hook.yml
+++ b/tests/manifests/vm_with_sidecar_hook.yml
@@ -14,7 +14,7 @@ spec:
       disks:
       - disk:
           bus: virtio
-        name: registrydisk
+        name: containerdisk
         volumeName: registryvolume
       - disk:
           bus: virtio
@@ -28,8 +28,8 @@ spec:
   terminationGracePeriodSeconds: 0
   volumes:
   - name: registryvolume
-    registryDisk:
-      image: kubevirt/fedora-cloud-registry-disk-demo:latest
+    containerDisk:
+      image: kubevirt/fedora-cloud-container-disk-demo:latest
   - cloudInitNoCloud:
       userData: |-
         #cloud-config

--- a/tests/manifests/vmi-ephemeral.yaml
+++ b/tests/manifests/vmi-ephemeral.yaml
@@ -11,7 +11,7 @@ spec:
       disks:
       - disk:
           bus: virtio
-        name: registrydisk
+        name: containerdisk
         volumeName: registryvolume
     machine:
       type: ""
@@ -21,6 +21,6 @@ spec:
   terminationGracePeriodSeconds: 0
   volumes:
   - name: registryvolume
-    registryDisk:
-      image: kubevirt/cirros-registry-disk-demo:latest
+    containerDisk:
+      image: kubevirt/cirros-container-disk-demo:latest
 status: {}

--- a/tests/manifests/vmi-replicaset-cirros.yaml
+++ b/tests/manifests/vmi-replicaset-cirros.yaml
@@ -19,7 +19,7 @@ spec:
           disks:
           - disk:
               bus: virtio
-            name: registrydisk
+            name: containerdisk
             volumeName: registryvolume
         machine:
           type: ""
@@ -29,6 +29,6 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - name: registryvolume
-        registryDisk:
-          image: kubevirt/cirros-registry-disk-demo:latest
+        containerDisk:
+          image: kubevirt/cirros-container-disk-demo:latest
 status: {}

--- a/tests/network_connectivity_test.go
+++ b/tests/network_connectivity_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Network Connectivity", func() {
 
 	tests.BeforeAll(func() {
 		for i := 0; i < 2; i++ {
-			vms[i] = tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.RegistryDiskFor(tests.RegistryDiskCirros), "#!/bin/bash\necho 'hello'\n")
+			vms[i] = tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 			vms[i], err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vms[i])
 			Expect(err).ToNot(HaveOccurred())
 			tests.WaitForSuccessfulVMIStart(vms[i])

--- a/tests/sanity_test.go
+++ b/tests/sanity_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Sanity", func() {
 
 	BeforeEach(func() {
 		tests.BeforeTestCleanup()
-		vmi = tests.NewRandomVMIWithEphemeralDisk(tests.RegistryDiskFor(tests.RegistryDiskAlpine))
+		vmi = tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskAlpine))
 	})
 
 	Describe("Creating a VM", func() {

--- a/tests/secrets_and_cfgmap_test.go
+++ b/tests/secrets_and_cfgmap_test.go
@@ -69,8 +69,8 @@ var _ = Describe("Config", func() {
 				By("Running VMI")
 
 				vmi := ktests.NewRandomVMIWithEphemeralDiskAndUserdataHighMemory(
-					ktests.RegistryDiskFor(
-						ktests.RegistryDiskFedora), "#!/bin/bash\necho \"fedora\" | passwd fedora --stdin\n")
+					ktests.ContainerDiskFor(
+						ktests.ContainerDiskFedora), "#!/bin/bash\necho \"fedora\" | passwd fedora --stdin\n")
 				ktests.AddConfigMapDisk(vmi, configMapName)
 				ktests.AddSecretDisk(vmi, secretName)
 				ktests.RunVMIAndExpectLaunch(vmi, false, 90)
@@ -169,8 +169,8 @@ var _ = Describe("Config", func() {
 
 				By("Running VMI")
 				vmi := ktests.NewRandomVMIWithEphemeralDiskAndUserdataHighMemory(
-					ktests.RegistryDiskFor(
-						ktests.RegistryDiskFedora), "#!/bin/bash\necho \"fedora\" | passwd fedora --stdin\n")
+					ktests.ContainerDiskFor(
+						ktests.ContainerDiskFedora), "#!/bin/bash\necho \"fedora\" | passwd fedora --stdin\n")
 				ktests.AddSecretDisk(vmi, secretName)
 				ktests.RunVMIAndExpectLaunch(vmi, false, 90)
 

--- a/tests/serviceaccount_test.go
+++ b/tests/serviceaccount_test.go
@@ -47,8 +47,8 @@ var _ = Describe("Config", func() {
 			It("Should be the fs layout the same for a pod and vmi", func() {
 				By("Running VMI")
 				vmi := ktests.NewRandomVMIWithEphemeralDiskAndUserdataHighMemory(
-					ktests.RegistryDiskFor(
-						ktests.RegistryDiskFedora), "#!/bin/bash\necho \"fedora\" | passwd fedora --stdin\n")
+					ktests.ContainerDiskFor(
+						ktests.ContainerDiskFedora), "#!/bin/bash\necho \"fedora\" | passwd fedora --stdin\n")
 				ktests.AddServiceAccountDisk(vmi, serviceAccountName)
 				ktests.RunVMIAndExpectLaunch(vmi, false, 90)
 
@@ -106,8 +106,8 @@ var _ = Describe("Config", func() {
 			It("Should not run the vm with 2 service accounts", func() {
 				By("Ensuring VMI is not running")
 				vmi := ktests.NewRandomVMIWithEphemeralDiskAndUserdataHighMemory(
-					ktests.RegistryDiskFor(
-						ktests.RegistryDiskFedora), "#!/bin/bash\necho \"fedora\" | passwd fedora --stdin\n")
+					ktests.ContainerDiskFor(
+						ktests.ContainerDiskFedora), "#!/bin/bash\necho \"fedora\" | passwd fedora --stdin\n")
 				ktests.AddServiceAccountDisk(vmi, serviceAccountName1)
 				ktests.AddServiceAccountDisk(vmi, serviceAccountName2)
 				_, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)

--- a/tests/virtio_rng_test.go
+++ b/tests/virtio_rng_test.go
@@ -40,7 +40,7 @@ var _ = Describe("VIRT RNG test", func() {
 
 	Context("With VirtIO RNG device", func() {
 		var withRngVmi *v1.VirtualMachineInstance
-		withRngVmi = ktests.NewRandomVMIWithEphemeralDisk(ktests.RegistryDiskFor(ktests.RegistryDiskAlpine))
+		withRngVmi = ktests.NewRandomVMIWithEphemeralDisk(ktests.ContainerDiskFor(ktests.ContainerDiskAlpine))
 		It("Virtio rng device should be present", func() {
 			withRngVmi.Spec.Domain.Devices.Rng = &v1.Rng{}
 


### PR DESCRIPTION
Signed-off-by: Kedar Bidarkar <kbidarka@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:  I handles the changes in API related to renaming of registryDisk to containerDisk.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # Various tests for CNV-1.4 related to registryDisk to containerDisk name change.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
This handles the rename of registryDisk to ContainerDisk
Also all the references to registryDisk have been attempted to be handled.
Things may fail unless the kubevirt is updated and it's PR merged first.
We need to merge this PR only after kubevirt version is bumped to `0.12.0-alpha2` and it's PR merged.

```
