### PR TITLE
fix kubevirt-web-ui tag when docker_tag is configured

### DIFF
--- a/automation/check-patch.sh
+++ b/automation/check-patch.sh
@@ -228,6 +228,10 @@ run() {
         -e "${args[*]}" \
         playbooks/automation/check-patch.yml
 
+    # TODO:(SchSeba) Remove this.
+    # Try to sleep before running the integration tests
+    sleep 30
+
     # Run integration tests
     wait "$MAKE_TESTS_PID" || {
         local ret="$?"

--- a/roles/kubevirt/tasks/deprovision.yml
+++ b/roles/kubevirt/tasks/deprovision.yml
@@ -66,7 +66,7 @@
   command: "{{ cluster_command }} delete -f /tmp/kubevirt.yaml --ignore-not-found=true --wait=false"
 
 - name: Wait until {{ namespace }} namespace will dissappear
-  shell: "{{ cluster_command }} get ns | grep -w {{ namespace }}"
+  shell: "{{ cluster_command }} get ns {{ namespace }}"
   register: result
   until: result.rc != 0
   retries: 12

--- a/roles/kubevirt_web_ui/tasks/required_params.yml
+++ b/roles/kubevirt_web_ui/tasks/required_params.yml
@@ -4,7 +4,7 @@
 - set_fact: kubevirt_web_ui_image_tag="v1.4.0"
   when: version is defined and "0.12." in version
 
-- set_fact: kubevirt_web_ui_image_tag="v{{ docker_tag }}"
+- set_fact: kubevirt_web_ui_image_tag="{{ docker_tag }}"
   when: docker_tag is defined
 
 - set_fact: kubevirt_web_ui_image_name="{{ registry_url }}/{{ registry_namespace }}/kubevirt-web-ui:{{ kubevirt_web_ui_image_tag | default("latest")}}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR remove the "v" character from the `set_fact: kubevirt_web_ui_image_tag`

This PR also fix the deprovision of kubevirt. when we check the kubevirt namespace
oc get ns | grep -w 'kubevirt'
kubevirt                            Active    1d
kubevirt-web-ui                     Active    1h

check the command to be 
oc get ns | grep 'kubevirt '  (space added)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt-ansible/535)
<!-- Reviewable:end -->
