### PR TITLE
Change the offline template to rpm template and increase multus timeout

### DIFF
--- a/roles/kubevirt/defaults/main.yml
+++ b/roles/kubevirt/defaults/main.yml
@@ -13,6 +13,7 @@ docker_tag: "v{{ version }}"
 image_pull_policy: IfNotPresent
 
 offline_template_dir: "/opt/apb/kubevirt-templates"
+common_templates_version: "0.3.2"
 
 default_vm_templates:
   - "vm-template-fedora"

--- a/roles/kubevirt/tasks/provision.yml
+++ b/roles/kubevirt/tasks/provision.yml
@@ -25,29 +25,31 @@
     path: "{{ kubevirt_template_dir }}/kubevirt.yaml.j2"
   register: byo_template
 
-- name: Check for kubevirt.yaml.j2 version v{{ version }} in {{ offline_template_dir }}
-  stat:
-    path: "{{ offline_template_dir }}/v{{ version }}/kubevirt.yaml.j2"
-  register: offline_templates
-  when: byo_template.stat.exists == False
-
-- name: Download KubeVirt Template
-  get_url:
-    url: "{{ release_manifest_url }}/v{{ version }}/kubevirt.yaml.j2"
-    dest: "{{ kubevirt_template_dir }}/kubevirt.yaml.j2"
-  when: byo_template.stat.exists == False and offline_templates.stat.exists == False
-
-- name: Render offline template
+- name: Render kubevirt.yaml.j2 template from  {{ kubevirt_template_dir }}
   template:
-    src: "{{ offline_template_dir }}/v{{ version }}/kubevirt.yaml.j2"
+    src: "{{ kubevirt_template_dir }}/kubevirt.yaml.j2"
     dest: "/tmp/kubevirt.yaml"
-  when: (offline_templates is not skipped) and (offline_templates.stat.exists == True)
+  when: byo_template.stat.exists == true
 
-- name: Render KubeVirt Yaml
-  template:
-    src: "kubevirt.yaml.j2"
-    dest: "/tmp/kubevirt.yaml"
-  when: (offline_templates is skipped) or (offline_templates.stat.exists == False)
+- name: get kubevirt-manifests from {{ release_manifest_url }}
+  block:
+  - name: Check for kubevirt.yaml.j2 template was downloaded to /tmp
+    stat:
+      path: "/tmp/kubevirt.yaml.j2"
+    register: downloaded_template
+
+  - name: Download KubeVirt Template
+    get_url:
+      url: "{{ release_manifest_url }}/v{{ version }}/kubevirt.yaml.j2"
+      dest: "/tmp/kubevirt.yaml.j2"
+    when: downloaded_template.stat.exists == false
+
+  - name: Render Downloaded KubeVirt Yaml
+    template:
+      src: "/tmp/kubevirt.yaml.j2"
+      dest: "/tmp/kubevirt.yaml"
+
+  when: byo_template.stat.exists == false
 
 - name: Create KubeVirt Resources
   command: "{{ cluster_command }} apply -f /tmp/kubevirt.yaml --validate=false"
@@ -90,54 +92,41 @@
       when: deploy_demo == true
 
 # VM Templates manifests
-- name: Check for vm templates in {{ kubevirt_template_dir }}
-  stat:
-    path: "{{ kubevirt_template_dir }}/{{ item }}.yaml"
-  with_items:
-    - "{{ default_vm_templates }}"
-  register: byo_vm_templates
+- name: install vm templates manifests
+  block:
+  - name: Check for vm templates in {{ kubevirt_template_dir }}
+    stat:
+      path: "{{ kubevirt_template_dir }}/common-templates.yaml"
+    register: byo_vm_templates
 
-- name: Copy VM templates to /tmp
-  copy:
-    src: "{{ kubevirt_template_dir }}/{{ item }}.yaml"
-    dest: "/tmp/{{ item }}.yaml"
-  with_items: "{{ byo_vm_templates.results | selectattr('stat.exists') | map(attribute='item') | list }}"
-  when: "{{ byo_vm_templates.results | selectattr('stat.exists') | map(attribute='item') | list | length > 0 }}"
+  - name: Apply vm templates from {{ kubevirt_template_dir }}/common-templates.yaml
+    command: "{{ cluster_command }} apply -f {{ kubevirt_template_dir }}/common-templates.yaml"
+    when: byo_vm_templates.stat.exists == true
 
-- name: Check for vm templates in {{ offline_template_dir }}
-  stat:
-    path: "{{ offline_template_dir }}/v{{ version }}/{{ item }}.yaml"
-  with_items:
-    - "{{ default_vm_templates }}"
-  register: offline_vm_templates
+  - name: Download KubeVirt VM templates
+    block:
+      - name: Download KubeVirt default VM templates for version < 0.6.0
+        get_url:
+          url: "https://raw.githubusercontent.com/kubevirt/kubevirt/v{{ version }}/cluster/examples/{{ item }}.yaml"
+          dest: "/tmp/{{ item }}.yaml"
+        with_items:
+          - "{{ default_vm_templates }}"
+        when: "version is version('0.6.0', '<')"
 
-- name: Copy VM templates to /tmp
-  copy:
-    src: "{{ offline_template_dir }}/v{{ version }}/{{ item }}.yaml"
-    dest: "/tmp/{{ item }}.yaml"
-  with_items: "{{ offline_vm_templates.results | selectattr('stat.exists') | map(attribute='item') | list }}"
-  when: "{{ offline_vm_templates.results | selectattr('stat.exists') | map(attribute='item') | list | length > 0 }}"
+      - name: Create default VM templates in OpenShift Namespace for version < 0.6.0
+        shell: "oc apply -f /tmp/{{ item }}.yaml -n openshift"
+        with_items:
+          - "{{ default_vm_templates }}"
+        when: "version is version('0.6.0', '<')"
 
-- name: Set the default VM templates URL
-  set_fact:
-    templates_url: "https://raw.githubusercontent.com/kubevirt/kubevirt/v{{ version }}/cluster/examples"
-  when: "{{ '0.6.0' is version(version, '<') }}"
+      - name: Download KubeVirt default VM templates for version >= 0.6.0
+        get_url:
+          url: "https://github.com/kubevirt/common-templates/releases/download/v{{ common_templates_version }}/common-templates-v{{ common_templates_version }}.yaml"
+          dest: "/tmp/common-templates-v{{ common_templates_version }}.yaml"
+        when: "version is version('0.6.0', '>=')"
 
-- name: Set the default VM templates URL
-  set_fact:
-    templates_url: "https://raw.githubusercontent.com/kubevirt/kubevirt/v{{ version }}/cluster"
-  when: "{{ '0.6.0' is version(version, '>=') }}"
-
-- name: Download KubeVirt default VM templates
-  get_url:
-    url: "{{ templates_url }}/{{ item }}.yaml"
-    dest: "/tmp/{{ item }}.yaml"
-  with_items:
-    - "{{ default_vm_templates }}"
-  when: platform == "openshift" and "{{ byo_vm_templates.results | selectattr('stat.exists') | map(attribute='item') | list | length == 0 }}" and "{{ offline_vm_templates.results | selectattr('stat.exists') | map(attribute='item') | list | length == 0 }}"
-
-- name: Create default VM templates in OpenShift Namespace
-  shell: "oc apply -f /tmp/{{ item }}.yaml -n openshift"
-  with_items:
-    - "{{ default_vm_templates }}"
+      - name: Create default VM templates in OpenShift Namespace for version >= 0.6.0
+        shell: "oc apply -f /tmp/common-templates-v{{ common_templates_version }}.yaml -n openshift"
+        when: "version is version('0.6.0', '>=')"
+    when: byo_vm_templates.stat.exists == false
   when: platform == "openshift"

--- a/roles/network-multus/tasks/provision.yml
+++ b/roles/network-multus/tasks/provision.yml
@@ -94,37 +94,37 @@
   shell: "{{ cluster_command }} -n {{ network_namespace }} get daemonset | grep {{ multus_provisioner_name }} | awk \'{ if ($3 == $4) print \"0\"; else print \"1\"}\'"
   register: result
   until: result.stdout == "0"
-  retries: 20
-  delay: 5
+  retries: 24
+  delay: 10
 
 - name: Wait until CNI plugins are running
   shell: "{{ cluster_command }} -n {{ network_namespace }} get daemonset | grep {{ cni_provisioner_name }} | awk \'{ if ($3 == $4) print \"0\"; else print \"1\"}\'"
   register: result
   until: result.stdout == "0"
-  retries: 20
-  delay: 5
+  retries: 24
+  delay: 10
   when: deploy_cni_plugins
 
 - name: Wait until OVS Plugin is running
   shell: "{{ cluster_command }} -n {{ network_namespace }} get daemonset | grep {{ ovs_provisioner_name }} | awk \'{ if ($3 == $4) print \"0\"; else print \"1\"}\'"
   register: result
   until: result.stdout == "0"
-  retries: 20
-  delay: 5
+  retries: 24
+  delay: 10
   when: deploy_ovs_plugin
 
 - name: Wait until SR-IOV DP plugin is running
   shell: "{{ cluster_command }} -n {{ network_namespace }} get daemonset | grep {{ sriovdp_provisioner_name }} | awk \'{ if ($3 == $4) print \"0\"; else print \"1\"}\'"
   register: result
   until: result.stdout == "0"
-  retries: 20
-  delay: 5
+  retries: 24
+  delay: 10
   when: deploy_sriov_plugin
 
 - name: Wait until SR-IOV CNI plugin is running
   shell: "{{ cluster_command }} -n {{ network_namespace }} get daemonset | grep {{ sriovcni_provisioner_name }} | awk \'{ if ($3 == $4) print \"0\"; else print \"1\"}\'"
   register: result
   until: result.stdout == "0"
-  retries: 20
-  delay: 5
+  retries: 24
+  delay: 10
   when: deploy_sriov_plugin


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR fix two BZ.
* https://bugzilla.redhat.com/show_bug.cgi?id=1664276
Run playbook as an unprivileged user (non-root)

* https://bugzilla.redhat.com/show_bug.cgi?id=1664274
For now I change update the timeout for the network playbook checks.
I cant find a better way right now to handle this issue

**Special notes for your reviewer**:
To run the playbook as an unprivileged user I just download the yaml file if required to /tmp and not to the playbook folder that need privileged.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Run playbook as an unprivileged user (non-root)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt-ansible/541)
<!-- Reviewable:end -->
