### PR TITLE
Web UI: Block playbook execution till deployment is finished

### DIFF
--- a/roles/kubevirt_web_ui/files/crds/kubevirt_v1alpha1_kwebui_cr.yaml
+++ b/roles/kubevirt_web_ui/files/crds/kubevirt_v1alpha1_kwebui_cr.yaml
@@ -3,7 +3,7 @@ kind: KWebUI
 metadata:
   name: kubevirt-web-ui
 spec:
-  version: "1.4.0-9"
+  version: "v1.4.0-9"
   registry_url: "quay.io"
   registry_namespace: "kubevirt"
   branding: "okdvirt"

--- a/roles/kubevirt_web_ui/tasks/main.yml
+++ b/roles/kubevirt_web_ui/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
-# TODO: wait for deprovision fo Web UI before removing the operator
 - name: Deprovision Web UI and its operator
   block:
     - include_tasks: "deprovision.web-ui.yml"

--- a/roles/kubevirt_web_ui/tasks/provision.web-ui.yml
+++ b/roles/kubevirt_web_ui/tasks/provision.web-ui.yml
@@ -48,3 +48,26 @@
       when: openshift_master_default_subdomain is defined
     - name: Create operator custom resource to (un)deploy the Web UI
       shell: "{{ cluster_command }} apply -f {{ mktemp.stdout }}/cr.yaml"
+
+# For details about the error, see logs of the operator pod
+# Example:  oc logs kubevirt-web-ui-operator-6dd9547864-pdcx5 -n kubevirt-web-ui
+- name: Wait until Web UI is ready
+  shell: "{{ cluster_command }} -n {{ kubevirt_web_ui_namespace }} get KWebUI kubevirt-web-ui -o yaml | grep -q 'phase: PROVISIONED' && echo -n DONE"
+  register: result
+  until: result.stdout == "DONE"
+  retries: 30
+  delay: 10
+  when: kubevirt_web_ui_version != ""
+
+# The Web UI is deprovisioned either when
+#   - KWebUI CR is missing
+#   - or KWebUI CR status.phase contains NOT_DEPLOYED
+# Alternatively the Deployments can be checked as well.  
+- name: Wait until Web UI is undeployed
+  shell: "({{ cluster_command }} get KWebUI kubevirt-web-ui | grep -q 'kubevirt-web-ui' || (echo -n 'MISSING'; exit 1)) && ({{ cluster_command }} get KWebUI kubevirt-web-ui -o yaml | grep -q 'phase: NOT_DEPLOYED' && echo -n NOT_DEPLOYED)"
+  register: result
+  until: result.stdout == "MISSING" or result.stdout == "NOT_DEPLOYED"
+  retries: 30
+  delay: 10
+  when: kubevirt_web_ui_version == ""
+

--- a/vars/all.yml
+++ b/vars/all.yml
@@ -27,6 +27,7 @@ deploy_skydive: false
 kubevirt_web_ui_operator_image_tag: "latest"
 kubevirt_web_ui_branding: "okdvirt"
 kubevirt_web_ui_version: "v1.4.0-9"
+#kubevirt_web_ui_version: ""
 
 #
 # Example: '"05:00.0", "05:00.1"'


### PR DESCRIPTION
**What this PR does / why we need it**: The Web UI playbook is blocked until initial deployment is successfully finished

When the playbook finishes, the system is already in the desired state.
The playbook fails if the desired state can not be reached.

**Special notes for your reviewer**:
Please do not merge this before #557 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
