### PR TITLE
Add templates deployment to kubevirt ansible

### DIFF
--- a/playbooks/kubevirt-ssp.yml
+++ b/playbooks/kubevirt-ssp.yml
@@ -1,0 +1,11 @@
+---
+- import_playbook: initial_configuration.yml
+
+- name: Deploy kubevirt-ssp role
+  hosts: localhost
+  connection: local
+  gather_facts: False
+  environment:
+    http_proxy: ""
+  roles:
+    - role: "kubevirt-ssp"

--- a/playbooks/kubevirt.yml
+++ b/playbooks/kubevirt.yml
@@ -22,3 +22,6 @@
 # Deploy cdi
 - import_playbook: cdi.yml
 
+# Deploy kubevirt ssp
+- import_playbook: kubevirt-ssp.yml
+  when: platform == "openshift"

--- a/roles/kubevirt-ssp/README.md
+++ b/roles/kubevirt-ssp/README.md
@@ -1,0 +1,1 @@
+Based on https://github.com/MarSik/kubevirt-ssp-operator/tree/master/roles/KubevirtSsp

--- a/roles/kubevirt-ssp/defaults/main.yml
+++ b/roles/kubevirt-ssp/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+kubevirt_templates_namespace: "{{ kubevirt_ssp_namespace | default('openshift') }}"
+kubevirt_ssp_files_dir: "{{ role_path }}/files"
+cluster_command: "oc" # in case the roles/playbook is not executed from kubevirt.yml

--- a/roles/kubevirt-ssp/files/common-templates-v0.4.1.yaml
+++ b/roles/kubevirt-ssp/files/common-templates-v0.4.1.yaml
@@ -1,0 +1,1374 @@
+# Version v0.4.1
+---
+# Source: dist/templates/centos7-generic-large.yaml
+apiVersion: v1
+kind: Template
+metadata:
+  name: centos7-generic-large
+  annotations:
+    openshift.io/display-name: "CentOS 7.0+ VM"
+    description: >-
+      This template can be used to create a VM suitable for
+      CentOS 7 and newer.
+      The template assumes that a PVC is available which is providing the
+      necessary CentOS disk image.
+    tags: "kubevirt,virtualmachine,linux,centos"
+
+    iconClass: "icon-centos"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+
+    template.cnv.io/version: v1alpha1
+    defaults.template.cnv.io/disk: rootdisk
+    template.cnv.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+
+    name.os.template.cnv.io/centos7.0: CentOS 7.0
+
+  labels:
+    os.template.cnv.io/centos7.0: "true"
+    workload.template.cnv.io/generic: "true"
+    flavor.template.cnv.io/large: "true"
+    template.cnv.io/type: "base"
+
+objects:
+- apiVersion: kubevirt.io/v1alpha3
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.cnv.io/template: centos7-generic-large
+      app: ${NAME}
+  spec:
+    running: false
+    template:
+      spec:
+        domain:
+
+          cpu:
+            sockets: 2
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 6G
+          devices:
+            rng: {}
+            disks:
+            - disk:
+                bus: virtio
+              name: rootdisk
+        terminationGracePeriodSeconds: 0
+        volumes:
+        - name: rootdisk
+          persistentVolumeClaim:
+            claimName: ${PVCNAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              password: centos
+              chpasswd: { expire: False }
+          name: cloudinitvolume
+
+parameters:
+- description: VM name
+  from: 'centos7-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: PVCNAME
+  description: Name of the PVC with the disk image
+  required: true
+
+---
+# Source: dist/templates/centos7-generic-medium.yaml
+apiVersion: v1
+kind: Template
+metadata:
+  name: centos7-generic-medium
+  annotations:
+    openshift.io/display-name: "CentOS 7.0+ VM"
+    description: >-
+      This template can be used to create a VM suitable for
+      CentOS 7 and newer.
+      The template assumes that a PVC is available which is providing the
+      necessary CentOS disk image.
+    tags: "kubevirt,virtualmachine,linux,centos"
+
+    iconClass: "icon-centos"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+
+    template.cnv.io/version: v1alpha1
+    defaults.template.cnv.io/disk: rootdisk
+    template.cnv.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+
+    name.os.template.cnv.io/centos7.0: CentOS 7.0
+
+  labels:
+    os.template.cnv.io/centos7.0: "true"
+    workload.template.cnv.io/generic: "true"
+    flavor.template.cnv.io/medium: "true"
+    template.cnv.io/type: "base"
+
+objects:
+- apiVersion: kubevirt.io/v1alpha3
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.cnv.io/template: centos7-generic-medium
+      app: ${NAME}
+  spec:
+    running: false
+    template:
+      spec:
+        domain:
+
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 4G
+          devices:
+            rng: {}
+            disks:
+            - disk:
+                bus: virtio
+              name: rootdisk
+        terminationGracePeriodSeconds: 0
+        volumes:
+        - name: rootdisk
+          persistentVolumeClaim:
+            claimName: ${PVCNAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              password: centos
+              chpasswd: { expire: False }
+          name: cloudinitvolume
+
+parameters:
+- description: VM name
+  from: 'centos7-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: PVCNAME
+  description: Name of the PVC with the disk image
+  required: true
+
+---
+# Source: dist/templates/centos7-generic-small.yaml
+apiVersion: v1
+kind: Template
+metadata:
+  name: centos7-generic-small
+  annotations:
+    openshift.io/display-name: "CentOS 7.0+ VM"
+    description: >-
+      This template can be used to create a VM suitable for
+      CentOS 7 and newer.
+      The template assumes that a PVC is available which is providing the
+      necessary CentOS disk image.
+    tags: "kubevirt,virtualmachine,linux,centos"
+
+    iconClass: "icon-centos"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+
+    template.cnv.io/version: v1alpha1
+    defaults.template.cnv.io/disk: rootdisk
+    template.cnv.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+
+    name.os.template.cnv.io/centos7.0: CentOS 7.0
+
+  labels:
+    os.template.cnv.io/centos7.0: "true"
+    workload.template.cnv.io/generic: "true"
+    flavor.template.cnv.io/small: "true"
+    template.cnv.io/type: "base"
+
+objects:
+- apiVersion: kubevirt.io/v1alpha3
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.cnv.io/template: centos7-generic-small
+      app: ${NAME}
+  spec:
+    running: false
+    template:
+      spec:
+        domain:
+
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 2G
+          devices:
+            rng: {}
+            disks:
+            - disk:
+                bus: virtio
+              name: rootdisk
+        terminationGracePeriodSeconds: 0
+        volumes:
+        - name: rootdisk
+          persistentVolumeClaim:
+            claimName: ${PVCNAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              password: centos
+              chpasswd: { expire: False }
+          name: cloudinitvolume
+
+parameters:
+- description: VM name
+  from: 'centos7-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: PVCNAME
+  description: Name of the PVC with the disk image
+  required: true
+
+---
+# Source: dist/templates/centos7-generic-tiny.yaml
+apiVersion: v1
+kind: Template
+metadata:
+  name: centos7-generic-tiny
+  annotations:
+    openshift.io/display-name: "CentOS 7.0+ VM"
+    description: >-
+      This template can be used to create a VM suitable for
+      CentOS 7 and newer.
+      The template assumes that a PVC is available which is providing the
+      necessary CentOS disk image.
+    tags: "kubevirt,virtualmachine,linux,centos"
+
+    iconClass: "icon-centos"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+
+    template.cnv.io/version: v1alpha1
+    defaults.template.cnv.io/disk: rootdisk
+    template.cnv.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+
+    name.os.template.cnv.io/centos7.0: CentOS 7.0
+
+  labels:
+    os.template.cnv.io/centos7.0: "true"
+    workload.template.cnv.io/generic: "true"
+    flavor.template.cnv.io/tiny: "true"
+    template.cnv.io/type: "base"
+
+objects:
+- apiVersion: kubevirt.io/v1alpha3
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.cnv.io/template: centos7-generic-tiny
+      app: ${NAME}
+  spec:
+    running: false
+    template:
+      spec:
+        domain:
+
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 1G
+          devices:
+            rng: {}
+            disks:
+            - disk:
+                bus: virtio
+              name: rootdisk
+        terminationGracePeriodSeconds: 0
+        volumes:
+        - name: rootdisk
+          persistentVolumeClaim:
+            claimName: ${PVCNAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              password: centos
+              chpasswd: { expire: False }
+          name: cloudinitvolume
+
+parameters:
+- description: VM name
+  from: 'centos7-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: PVCNAME
+  description: Name of the PVC with the disk image
+  required: true
+
+---
+# Source: dist/templates/rhel7-generic-large.yaml
+apiVersion: v1
+kind: Template
+metadata:
+  name: rhel7-generic-large
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 7.0+ VM"
+    description: >-
+      This template can be used to create a VM suitable for
+      Red Hat Enterprise Linux 7 and newer.
+      The template assumes that a PVC is available which is providing the
+      necessary RHEL disk image.
+    tags: "kubevirt,virtualmachine,linux,rhel"
+
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+
+    template.cnv.io/version: v1alpha1
+    defaults.template.cnv.io/disk: rootdisk
+    template.cnv.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+
+    name.os.template.cnv.io/rhel7.0: Red Hat Enterprise Linux 7.0
+    name.os.template.cnv.io/rhel7.1: Red Hat Enterprise Linux 7.1
+    name.os.template.cnv.io/rhel7.2: Red Hat Enterprise Linux 7.2
+    name.os.template.cnv.io/rhel7.3: Red Hat Enterprise Linux 7.3
+    name.os.template.cnv.io/rhel7.4: Red Hat Enterprise Linux 7.4
+    name.os.template.cnv.io/rhel7.5: Red Hat Enterprise Linux 7.5
+    name.os.template.cnv.io/rhel7.6: Red Hat Enterprise Linux 7.6
+
+  labels:
+    os.template.cnv.io/rhel7.0: "true"
+    os.template.cnv.io/rhel7.1: "true"
+    os.template.cnv.io/rhel7.2: "true"
+    os.template.cnv.io/rhel7.3: "true"
+    os.template.cnv.io/rhel7.4: "true"
+    os.template.cnv.io/rhel7.5: "true"
+    os.template.cnv.io/rhel7.6: "true"
+    workload.template.cnv.io/generic: "true"
+    flavor.template.cnv.io/large: "true"
+    template.cnv.io/type: "base"
+
+objects:
+- apiVersion: kubevirt.io/v1alpha3
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.cnv.io/template: rhel7-generic-large
+      app: ${NAME}
+  spec:
+    running: false
+    template:
+      spec:
+        domain:
+
+          cpu:
+            sockets: 2
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 6G
+          devices:
+            rng: {}
+            disks:
+            - disk:
+                bus: virtio
+              name: rootdisk
+        terminationGracePeriodSeconds: 0
+        volumes:
+        - name: rootdisk
+          persistentVolumeClaim:
+            claimName: ${PVCNAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              password: redhat
+              chpasswd: { expire: False }
+          name: cloudinitvolume
+
+parameters:
+- description: VM name
+  from: 'rhel7-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: PVCNAME
+  description: Name of the PVC with the disk image
+  required: true
+
+---
+# Source: dist/templates/rhel7-generic-medium.yaml
+apiVersion: v1
+kind: Template
+metadata:
+  name: rhel7-generic-medium
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 7.0+ VM"
+    description: >-
+      This template can be used to create a VM suitable for
+      Red Hat Enterprise Linux 7 and newer.
+      The template assumes that a PVC is available which is providing the
+      necessary RHEL disk image.
+    tags: "kubevirt,virtualmachine,linux,rhel"
+
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+
+    template.cnv.io/version: v1alpha1
+    defaults.template.cnv.io/disk: rootdisk
+    template.cnv.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+
+    name.os.template.cnv.io/rhel7.0: Red Hat Enterprise Linux 7.0
+    name.os.template.cnv.io/rhel7.1: Red Hat Enterprise Linux 7.1
+    name.os.template.cnv.io/rhel7.2: Red Hat Enterprise Linux 7.2
+    name.os.template.cnv.io/rhel7.3: Red Hat Enterprise Linux 7.3
+    name.os.template.cnv.io/rhel7.4: Red Hat Enterprise Linux 7.4
+    name.os.template.cnv.io/rhel7.5: Red Hat Enterprise Linux 7.5
+    name.os.template.cnv.io/rhel7.6: Red Hat Enterprise Linux 7.6
+
+  labels:
+    os.template.cnv.io/rhel7.0: "true"
+    os.template.cnv.io/rhel7.1: "true"
+    os.template.cnv.io/rhel7.2: "true"
+    os.template.cnv.io/rhel7.3: "true"
+    os.template.cnv.io/rhel7.4: "true"
+    os.template.cnv.io/rhel7.5: "true"
+    os.template.cnv.io/rhel7.6: "true"
+    workload.template.cnv.io/generic: "true"
+    flavor.template.cnv.io/medium: "true"
+    template.cnv.io/type: "base"
+
+objects:
+- apiVersion: kubevirt.io/v1alpha3
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.cnv.io/template: rhel7-generic-medium
+      app: ${NAME}
+  spec:
+    running: false
+    template:
+      spec:
+        domain:
+
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 4G
+          devices:
+            rng: {}
+            disks:
+            - disk:
+                bus: virtio
+              name: rootdisk
+        terminationGracePeriodSeconds: 0
+        volumes:
+        - name: rootdisk
+          persistentVolumeClaim:
+            claimName: ${PVCNAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              password: redhat
+              chpasswd: { expire: False }
+          name: cloudinitvolume
+
+parameters:
+- description: VM name
+  from: 'rhel7-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: PVCNAME
+  description: Name of the PVC with the disk image
+  required: true
+
+---
+# Source: dist/templates/rhel7-generic-small.yaml
+apiVersion: v1
+kind: Template
+metadata:
+  name: rhel7-generic-small
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 7.0+ VM"
+    description: >-
+      This template can be used to create a VM suitable for
+      Red Hat Enterprise Linux 7 and newer.
+      The template assumes that a PVC is available which is providing the
+      necessary RHEL disk image.
+    tags: "kubevirt,virtualmachine,linux,rhel"
+
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+
+    template.cnv.io/version: v1alpha1
+    defaults.template.cnv.io/disk: rootdisk
+    template.cnv.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+
+    name.os.template.cnv.io/rhel7.0: Red Hat Enterprise Linux 7.0
+    name.os.template.cnv.io/rhel7.1: Red Hat Enterprise Linux 7.1
+    name.os.template.cnv.io/rhel7.2: Red Hat Enterprise Linux 7.2
+    name.os.template.cnv.io/rhel7.3: Red Hat Enterprise Linux 7.3
+    name.os.template.cnv.io/rhel7.4: Red Hat Enterprise Linux 7.4
+    name.os.template.cnv.io/rhel7.5: Red Hat Enterprise Linux 7.5
+    name.os.template.cnv.io/rhel7.6: Red Hat Enterprise Linux 7.6
+
+  labels:
+    os.template.cnv.io/rhel7.0: "true"
+    os.template.cnv.io/rhel7.1: "true"
+    os.template.cnv.io/rhel7.2: "true"
+    os.template.cnv.io/rhel7.3: "true"
+    os.template.cnv.io/rhel7.4: "true"
+    os.template.cnv.io/rhel7.5: "true"
+    os.template.cnv.io/rhel7.6: "true"
+    workload.template.cnv.io/generic: "true"
+    flavor.template.cnv.io/small: "true"
+    template.cnv.io/type: "base"
+
+objects:
+- apiVersion: kubevirt.io/v1alpha3
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.cnv.io/template: rhel7-generic-small
+      app: ${NAME}
+  spec:
+    running: false
+    template:
+      spec:
+        domain:
+
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 2G
+          devices:
+            rng: {}
+            disks:
+            - disk:
+                bus: virtio
+              name: rootdisk
+        terminationGracePeriodSeconds: 0
+        volumes:
+        - name: rootdisk
+          persistentVolumeClaim:
+            claimName: ${PVCNAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              password: redhat
+              chpasswd: { expire: False }
+          name: cloudinitvolume
+
+parameters:
+- description: VM name
+  from: 'rhel7-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: PVCNAME
+  description: Name of the PVC with the disk image
+  required: true
+
+---
+# Source: dist/templates/rhel7-generic-tiny.yaml
+apiVersion: v1
+kind: Template
+metadata:
+  name: rhel7-generic-tiny
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 7.0+ VM"
+    description: >-
+      This template can be used to create a VM suitable for
+      Red Hat Enterprise Linux 7 and newer.
+      The template assumes that a PVC is available which is providing the
+      necessary RHEL disk image.
+    tags: "kubevirt,virtualmachine,linux,rhel"
+
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+
+    template.cnv.io/version: v1alpha1
+    defaults.template.cnv.io/disk: rootdisk
+    template.cnv.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+
+    name.os.template.cnv.io/rhel7.0: Red Hat Enterprise Linux 7.0
+    name.os.template.cnv.io/rhel7.1: Red Hat Enterprise Linux 7.1
+    name.os.template.cnv.io/rhel7.2: Red Hat Enterprise Linux 7.2
+    name.os.template.cnv.io/rhel7.3: Red Hat Enterprise Linux 7.3
+    name.os.template.cnv.io/rhel7.4: Red Hat Enterprise Linux 7.4
+    name.os.template.cnv.io/rhel7.5: Red Hat Enterprise Linux 7.5
+    name.os.template.cnv.io/rhel7.6: Red Hat Enterprise Linux 7.6
+
+  labels:
+    os.template.cnv.io/rhel7.0: "true"
+    os.template.cnv.io/rhel7.1: "true"
+    os.template.cnv.io/rhel7.2: "true"
+    os.template.cnv.io/rhel7.3: "true"
+    os.template.cnv.io/rhel7.4: "true"
+    os.template.cnv.io/rhel7.5: "true"
+    os.template.cnv.io/rhel7.6: "true"
+    workload.template.cnv.io/generic: "true"
+    flavor.template.cnv.io/tiny: "true"
+    template.cnv.io/type: "base"
+
+objects:
+- apiVersion: kubevirt.io/v1alpha3
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.cnv.io/template: rhel7-generic-tiny
+      app: ${NAME}
+  spec:
+    running: false
+    template:
+      spec:
+        domain:
+
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 1G
+          devices:
+            rng: {}
+            disks:
+            - disk:
+                bus: virtio
+              name: rootdisk
+        terminationGracePeriodSeconds: 0
+        volumes:
+        - name: rootdisk
+          persistentVolumeClaim:
+            claimName: ${PVCNAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              password: redhat
+              chpasswd: { expire: False }
+          name: cloudinitvolume
+
+parameters:
+- description: VM name
+  from: 'rhel7-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: PVCNAME
+  description: Name of the PVC with the disk image
+  required: true
+
+---
+# Source: dist/templates/rhel7-highperformance-large.yaml
+apiVersion: v1
+kind: Template
+metadata:
+  name: rhel7-highperformance-large
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 7.0+ VM"
+    description: >-
+      This template can be used to create a VM suitable for
+      Red Hat Enterprise Linux 7 and newer.
+      The template assumes that a PVC is available which is providing the
+      necessary RHEL disk image.
+    tags: "kubevirt,virtualmachine,linux,rhel"
+
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+
+    template.cnv.io/version: v1alpha1
+    defaults.template.cnv.io/disk: rootdisk
+    template.cnv.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+
+    name.os.template.cnv.io/rhel7.0: Red Hat Enterprise Linux 7.0
+    name.os.template.cnv.io/rhel7.1: Red Hat Enterprise Linux 7.1
+    name.os.template.cnv.io/rhel7.2: Red Hat Enterprise Linux 7.2
+    name.os.template.cnv.io/rhel7.3: Red Hat Enterprise Linux 7.3
+    name.os.template.cnv.io/rhel7.4: Red Hat Enterprise Linux 7.4
+    name.os.template.cnv.io/rhel7.5: Red Hat Enterprise Linux 7.5
+    name.os.template.cnv.io/rhel7.6: Red Hat Enterprise Linux 7.6
+
+  labels:
+    os.template.cnv.io/rhel7.0: "true"
+    os.template.cnv.io/rhel7.1: "true"
+    os.template.cnv.io/rhel7.2: "true"
+    os.template.cnv.io/rhel7.3: "true"
+    os.template.cnv.io/rhel7.4: "true"
+    os.template.cnv.io/rhel7.5: "true"
+    os.template.cnv.io/rhel7.6: "true"
+    workload.template.cnv.io/highperformance: "true"
+    flavor.template.cnv.io/large: "true"
+    template.cnv.io/type: "base"
+
+objects:
+- apiVersion: kubevirt.io/v1alpha3
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.cnv.io/template: rhel7-highperformance-large
+      app: ${NAME}
+  spec:
+    running: false
+    template:
+      spec:
+        domain:
+          ioThreadsPolicy: shared
+
+          cpu:
+            sockets: 2
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 6G
+          devices:
+            rng: {}
+            disks:
+            - disk:
+                bus: virtio
+              name: rootdisk
+        terminationGracePeriodSeconds: 0
+        volumes:
+        - name: rootdisk
+          persistentVolumeClaim:
+            claimName: ${PVCNAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              password: redhat
+              chpasswd: { expire: False }
+          name: cloudinitvolume
+
+parameters:
+- description: VM name
+  from: 'rhel7-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: PVCNAME
+  description: Name of the PVC with the disk image
+  required: true
+
+---
+# Source: dist/templates/rhel7-highperformance-medium.yaml
+apiVersion: v1
+kind: Template
+metadata:
+  name: rhel7-highperformance-medium
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 7.0+ VM"
+    description: >-
+      This template can be used to create a VM suitable for
+      Red Hat Enterprise Linux 7 and newer.
+      The template assumes that a PVC is available which is providing the
+      necessary RHEL disk image.
+    tags: "kubevirt,virtualmachine,linux,rhel"
+
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+
+    template.cnv.io/version: v1alpha1
+    defaults.template.cnv.io/disk: rootdisk
+    template.cnv.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+
+    name.os.template.cnv.io/rhel7.0: Red Hat Enterprise Linux 7.0
+    name.os.template.cnv.io/rhel7.1: Red Hat Enterprise Linux 7.1
+    name.os.template.cnv.io/rhel7.2: Red Hat Enterprise Linux 7.2
+    name.os.template.cnv.io/rhel7.3: Red Hat Enterprise Linux 7.3
+    name.os.template.cnv.io/rhel7.4: Red Hat Enterprise Linux 7.4
+    name.os.template.cnv.io/rhel7.5: Red Hat Enterprise Linux 7.5
+    name.os.template.cnv.io/rhel7.6: Red Hat Enterprise Linux 7.6
+
+  labels:
+    os.template.cnv.io/rhel7.0: "true"
+    os.template.cnv.io/rhel7.1: "true"
+    os.template.cnv.io/rhel7.2: "true"
+    os.template.cnv.io/rhel7.3: "true"
+    os.template.cnv.io/rhel7.4: "true"
+    os.template.cnv.io/rhel7.5: "true"
+    os.template.cnv.io/rhel7.6: "true"
+    workload.template.cnv.io/highperformance: "true"
+    flavor.template.cnv.io/medium: "true"
+    template.cnv.io/type: "base"
+
+objects:
+- apiVersion: kubevirt.io/v1alpha3
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.cnv.io/template: rhel7-highperformance-medium
+      app: ${NAME}
+  spec:
+    running: false
+    template:
+      spec:
+        domain:
+          ioThreadsPolicy: shared
+
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 4G
+          devices:
+            rng: {}
+            disks:
+            - disk:
+                bus: virtio
+              name: rootdisk
+        terminationGracePeriodSeconds: 0
+        volumes:
+        - name: rootdisk
+          persistentVolumeClaim:
+            claimName: ${PVCNAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              password: redhat
+              chpasswd: { expire: False }
+          name: cloudinitvolume
+
+parameters:
+- description: VM name
+  from: 'rhel7-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: PVCNAME
+  description: Name of the PVC with the disk image
+  required: true
+
+---
+# Source: dist/templates/rhel7-highperformance-small.yaml
+apiVersion: v1
+kind: Template
+metadata:
+  name: rhel7-highperformance-small
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 7.0+ VM"
+    description: >-
+      This template can be used to create a VM suitable for
+      Red Hat Enterprise Linux 7 and newer.
+      The template assumes that a PVC is available which is providing the
+      necessary RHEL disk image.
+    tags: "kubevirt,virtualmachine,linux,rhel"
+
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+
+    template.cnv.io/version: v1alpha1
+    defaults.template.cnv.io/disk: rootdisk
+    template.cnv.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+
+    name.os.template.cnv.io/rhel7.0: Red Hat Enterprise Linux 7.0
+    name.os.template.cnv.io/rhel7.1: Red Hat Enterprise Linux 7.1
+    name.os.template.cnv.io/rhel7.2: Red Hat Enterprise Linux 7.2
+    name.os.template.cnv.io/rhel7.3: Red Hat Enterprise Linux 7.3
+    name.os.template.cnv.io/rhel7.4: Red Hat Enterprise Linux 7.4
+    name.os.template.cnv.io/rhel7.5: Red Hat Enterprise Linux 7.5
+    name.os.template.cnv.io/rhel7.6: Red Hat Enterprise Linux 7.6
+
+  labels:
+    os.template.cnv.io/rhel7.0: "true"
+    os.template.cnv.io/rhel7.1: "true"
+    os.template.cnv.io/rhel7.2: "true"
+    os.template.cnv.io/rhel7.3: "true"
+    os.template.cnv.io/rhel7.4: "true"
+    os.template.cnv.io/rhel7.5: "true"
+    os.template.cnv.io/rhel7.6: "true"
+    workload.template.cnv.io/highperformance: "true"
+    flavor.template.cnv.io/small: "true"
+    template.cnv.io/type: "base"
+
+objects:
+- apiVersion: kubevirt.io/v1alpha3
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.cnv.io/template: rhel7-highperformance-small
+      app: ${NAME}
+  spec:
+    running: false
+    template:
+      spec:
+        domain:
+          ioThreadsPolicy: shared
+
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 2G
+          devices:
+            rng: {}
+            disks:
+            - disk:
+                bus: virtio
+              name: rootdisk
+        terminationGracePeriodSeconds: 0
+        volumes:
+        - name: rootdisk
+          persistentVolumeClaim:
+            claimName: ${PVCNAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              password: redhat
+              chpasswd: { expire: False }
+          name: cloudinitvolume
+
+parameters:
+- description: VM name
+  from: 'rhel7-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: PVCNAME
+  description: Name of the PVC with the disk image
+  required: true
+
+---
+# Source: dist/templates/rhel7-highperformance-tiny.yaml
+apiVersion: v1
+kind: Template
+metadata:
+  name: rhel7-highperformance-tiny
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 7.0+ VM"
+    description: >-
+      This template can be used to create a VM suitable for
+      Red Hat Enterprise Linux 7 and newer.
+      The template assumes that a PVC is available which is providing the
+      necessary RHEL disk image.
+    tags: "kubevirt,virtualmachine,linux,rhel"
+
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+
+    template.cnv.io/version: v1alpha1
+    defaults.template.cnv.io/disk: rootdisk
+    template.cnv.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+
+    name.os.template.cnv.io/rhel7.0: Red Hat Enterprise Linux 7.0
+    name.os.template.cnv.io/rhel7.1: Red Hat Enterprise Linux 7.1
+    name.os.template.cnv.io/rhel7.2: Red Hat Enterprise Linux 7.2
+    name.os.template.cnv.io/rhel7.3: Red Hat Enterprise Linux 7.3
+    name.os.template.cnv.io/rhel7.4: Red Hat Enterprise Linux 7.4
+    name.os.template.cnv.io/rhel7.5: Red Hat Enterprise Linux 7.5
+    name.os.template.cnv.io/rhel7.6: Red Hat Enterprise Linux 7.6
+
+  labels:
+    os.template.cnv.io/rhel7.0: "true"
+    os.template.cnv.io/rhel7.1: "true"
+    os.template.cnv.io/rhel7.2: "true"
+    os.template.cnv.io/rhel7.3: "true"
+    os.template.cnv.io/rhel7.4: "true"
+    os.template.cnv.io/rhel7.5: "true"
+    os.template.cnv.io/rhel7.6: "true"
+    workload.template.cnv.io/highperformance: "true"
+    flavor.template.cnv.io/tiny: "true"
+    template.cnv.io/type: "base"
+
+objects:
+- apiVersion: kubevirt.io/v1alpha3
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.cnv.io/template: rhel7-highperformance-tiny
+      app: ${NAME}
+  spec:
+    running: false
+    template:
+      spec:
+        domain:
+          ioThreadsPolicy: shared
+
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 1G
+          devices:
+            rng: {}
+            disks:
+            - disk:
+                bus: virtio
+              name: rootdisk
+        terminationGracePeriodSeconds: 0
+        volumes:
+        - name: rootdisk
+          persistentVolumeClaim:
+            claimName: ${PVCNAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              password: redhat
+              chpasswd: { expire: False }
+          name: cloudinitvolume
+
+parameters:
+- description: VM name
+  from: 'rhel7-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: PVCNAME
+  description: Name of the PVC with the disk image
+  required: true
+
+---
+# Source: dist/templates/win2k12r2-generic-large.yaml
+apiVersion: v1
+kind: Template
+metadata:
+  name: win2k12r2-generic-large
+  annotations:
+    openshift.io/display-name: "Microsoft Windows Server 2012 R2 VM"
+    description: >-
+      This template can be used to create a VM suitable for
+      Microsoft Windows Server 2012 R2.
+      The template assumes that a PVC is available which is providing the
+      necessary Windows disk image.
+    tags: "kubevirt,virtualmachine,windows"
+    iconClass: "icon-windows"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+
+    template.cnv.io/version: v1alpha1
+    defaults.template.cnv.io/disk: rootdisk
+    defaults.template.cnv.io/network: default
+    template.cnv.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+
+    name.os.template.cnv.io/win2k12r2: Microsoft Windows Server 2012 R2
+    name.os.template.cnv.io/win2k8r2: Microsoft Windows Server 2008 R2
+    name.os.template.cnv.io/win2k8: Microsoft Windows Server 2008
+    name.os.template.cnv.io/win10: Microsoft Windows 10
+
+  labels:
+    os.template.cnv.io/win2k12r2: "true"
+    os.template.cnv.io/win2k8r2: "true"
+    os.template.cnv.io/win2k8: "true"
+    os.template.cnv.io/win10: "true"
+    workload.template.cnv.io/generic: "true"
+    flavor.template.cnv.io/large: "true"
+    template.cnv.io/type: "base"
+
+objects:
+- apiVersion: kubevirt.io/v1alpha3
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.cnv.io/template: win2k12r2-generic-large
+      app: ${NAME}
+  spec:
+    running: false
+    template:
+      spec:
+        domain:
+          clock:
+            utc: {}
+            timer:
+              hpet:
+                present: false
+              pit:
+                tickPolicy: delay
+              rtc:
+                tickPolicy: catchup
+              hyperv: {}
+          cpu:
+            sockets: 2
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 6G
+          features:
+            acpi: {}
+            apic: {}
+            hyperv:
+              relaxed: {}
+              vapic: {}
+              spinlocks:
+                spinlocks: 8191
+          devices:
+            disks:
+            - disk:
+                bus: sata
+              name: rootdisk
+            interfaces:
+            - bridge: {}
+              model: e1000e
+              name: default
+        terminationGracePeriodSeconds: 0
+        volumes:
+        - name: rootdisk
+          persistentVolumeClaim:
+            claimName: ${PVCNAME}
+        networks:
+        - name: default
+          pod: {}
+
+parameters:
+- name: NAME
+  description: VM name
+  generate: expression
+  from: "win2k12-[a-z0-9]{6}"
+- name: PVCNAME
+  description: Name of the PVC with the disk image
+  required: true
+---
+
+# Source: dist/templates/win2k12r2-generic-medium.yaml
+apiVersion: v1
+kind: Template
+metadata:
+  name: win2k12r2-generic-medium
+  annotations:
+    openshift.io/display-name: "Microsoft Windows Server 2012 R2 VM"
+    description: >-
+      This template can be used to create a VM suitable for
+      Microsoft Windows Server 2012 R2.
+      The template assumes that a PVC is available which is providing the
+      necessary Windows disk image.
+    tags: "kubevirt,virtualmachine,windows"
+    iconClass: "icon-windows"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+
+    template.cnv.io/version: v1alpha1
+    defaults.template.cnv.io/disk: rootdisk
+    defaults.template.cnv.io/network: default
+    template.cnv.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+
+    name.os.template.cnv.io/win2k12r2: Microsoft Windows Server 2012 R2
+    name.os.template.cnv.io/win2k8r2: Microsoft Windows Server 2008 R2
+    name.os.template.cnv.io/win2k8: Microsoft Windows Server 2008
+    name.os.template.cnv.io/win10: Microsoft Windows 10
+
+  labels:
+    os.template.cnv.io/win2k12r2: "true"
+    os.template.cnv.io/win2k8r2: "true"
+    os.template.cnv.io/win2k8: "true"
+    os.template.cnv.io/win10: "true"
+    workload.template.cnv.io/generic: "true"
+    flavor.template.cnv.io/medium: "true"
+    template.cnv.io/type: "base"
+
+objects:
+- apiVersion: kubevirt.io/v1alpha3
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.cnv.io/template: win2k12r2-generic-medium
+      app: ${NAME}
+  spec:
+    running: false
+    template:
+      spec:
+        domain:
+          clock:
+            utc: {}
+            timer:
+              hpet:
+                present: false
+              pit:
+                tickPolicy: delay
+              rtc:
+                tickPolicy: catchup
+              hyperv: {}
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 4G
+          features:
+            acpi: {}
+            apic: {}
+            hyperv:
+              relaxed: {}
+              vapic: {}
+              spinlocks:
+                spinlocks: 8191
+          devices:
+            disks:
+            - disk:
+                bus: sata
+              name: rootdisk
+            interfaces:
+            - bridge: {}
+              model: e1000e
+              name: default
+        terminationGracePeriodSeconds: 0
+        volumes:
+        - name: rootdisk
+          persistentVolumeClaim:
+            claimName: ${PVCNAME}
+        networks:
+        - name: default
+          pod: {}
+
+parameters:
+- name: NAME
+  description: VM name
+  generate: expression
+  from: "win2k12-[a-z0-9]{6}"
+- name: PVCNAME
+  description: Name of the PVC with the disk image
+  required: true

--- a/roles/kubevirt-ssp/tasks/deprovision.yml
+++ b/roles/kubevirt-ssp/tasks/deprovision.yml
@@ -1,0 +1,14 @@
+---
+- name: Check that common-templates.yaml still exists in /tmp
+  stat:
+    path: "/tmp/common-templates.yaml"
+  register: common_templates
+
+- name: Copy common templates yaml to temp directory
+  copy:
+    src: "{{ kubevirt_ssp_files_dir }}/common-templates-v0.4.1.yaml"
+    dest: "/tmp/common-templates.yaml"  
+  when: common_templates.stat.exists == false
+
+- name: Delete Kubevirt Templates
+  shell: "{{ cluster_command }} delete -f /tmp/common-templates.yaml -n {{ kubevirt_templates_namespace }}"

--- a/roles/kubevirt-ssp/tasks/main.yml
+++ b/roles/kubevirt-ssp/tasks/main.yml
@@ -1,0 +1,2 @@
+---
+- include_tasks: "{{ apb_action }}.yml"

--- a/roles/kubevirt-ssp/tasks/provision.yml
+++ b/roles/kubevirt-ssp/tasks/provision.yml
@@ -1,0 +1,15 @@
+---
+- name: Check that common-templates.yaml still exists in /tmp
+  stat:
+    path: "/tmp/common-templates.yaml"
+  register: common_templates
+
+- name: Copy common templates yaml to temp directory
+  copy:
+    src: "{{ kubevirt_ssp_files_dir }}/common-templates-v0.4.1.yaml"
+    dest: "/tmp/common-templates.yaml"  
+  when: common_templates.stat.exists == false
+
+- name: Create Kubevirt Template
+  shell: "{{ cluster_command }} apply -f /tmp/common-templates.yaml -n {{ kubevirt_templates_namespace }}"
+  


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Add deployment of common templates using kubevirt ansible based on [templates v0.4.0](https://github.com/kubevirt/common-templates/releases/tag/v0.4.0)
The templates included here are for : cenots7, rhel7 and win2k12r2 (this is cut from the common-templates file)

**Special notes for your reviewer**:
This is a temporary deployment solution until we use deployment with ssp-operator (ansible operator sdk)
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
deploy kubevirt templates 
```
