### PR TITLE
Replace kubevirt deploy tasks with the operator (#536)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@ KubeVirt Ansible consists of a set of Ansible playbooks that deploy fully functi
 ## Usage
 
 ### Deploy
-To deploy KubeVirt on an existing OpenShift cluster run the command below. For more information on clusters and other deployment scenarious see [playbooks instructions](./playbooks/README.md).
+To deploy KubeVirt on an existing OpenShift cluster run the commands below. For more information on clusters and other deployment scenarious see [playbooks instructions](./playbooks/README.md).
 
 ```
+oc login -u <admin_user> -p <admin_password>
+
 ansible-playbook -i localhost playbooks/kubevirt.yml -e@vars/all.yml
 ```
 >**Note:** Check default variables in [vars/all.yml](./vars/all.yml) and update them if needed.

--- a/roles/kubevirt/defaults/main.yml
+++ b/roles/kubevirt/defaults/main.yml
@@ -6,7 +6,6 @@ docker_prefix: "{{ registry_url }}/{{ registry_namespace }}"
 platform: "openshift"
 
 apb_action: "provision"
-release_manifest_url: "https://github.com/kubevirt/kubevirt/releases/download"
 kubevirt_template_dir: "{{ role_path }}/templates"
 version: 0.12.0-alpha.2
 docker_tag: "v{{ version }}"

--- a/roles/kubevirt/tasks/deprovision.yml
+++ b/roles/kubevirt/tasks/deprovision.yml
@@ -1,74 +1,111 @@
 ---
-# Demo content
-- name: Check that demo-content.yaml still exists in /tmp
+- name: Check that kubevirt-cr.yaml still exists in /tmp
   stat:
-    path: "/tmp/demo-content.yaml"
-  register: demo_content_manifest
+    path: "/tmp/kubevirt-cr.yaml"
+  register: kubevirt_cr
 
-- name: Check for demo-content.yaml template in {{ kubevirt_template_dir }}
-  stat:
-    path: "{{ kubevirt_template_dir }}/demo-content.yaml"
-  register: byo_demo_content
-  when: demo_content_manifest.stat.exists == False
-
-- name: Download Demo Content
-  get_url:
-    url: "{{ release_manifest_url }}/v{{ version }}/demo-content.yaml"
-    dest: "{{ kubevirt_template_dir }}/demo-content.yaml"
-  when: demo_content_manifest.stat.exists == False and byo_demo_content.stat.exists == False
-
-- name: Copy BYO Demo Content to /tmp
-  copy:
-    src: "{{ kubevirt_template_dir }}/demo-content.yaml"
-    dest: "/tmp/demo-content.yaml"
-  when: demo_content_manifest.stat.exists == False and byo_demo_content.stat.exists == False
-
-- name: Delete Demo Content
-  command: "{{ cluster_command }} delete --ignore-not-found=true -f /tmp/demo-content.yaml"
-
-- name: Delete Privileged Policy
-  command: "oc adm policy remove-scc-from-user privileged -z {{ item }} -n {{ namespace }}"
-  with_items: "{{ kubevirt_privileged_policies | list }}"
-  when: platform=="openshift"
-
-- name: Delete Hostmount-anyuid Policy
-  command: "oc adm policy remove-scc-from-user hostmount-anyuid -z kubevirt-infra -n {{ namespace }}"
-  when: platform=="openshift"
-
-# KubeVirt manifests
-- name: Check that kubevirt.yaml still exists in /tmp
-  stat:
-    path: "/tmp/kubevirt.yaml"
-  register: kubevirt_template
-
-- name: Check for kubevirt.yml.j2 template in {{ kubevirt_template_dir }}
-  stat:
-    path: "{{ kubevirt_template_dir }}/kubevirt.yaml.j2"
-  register: byo_template
-  when: kubevirt_template.stat.exists == False
-
-- name: Download KubeVirt Template
-  get_url:
-    url: "{{ release_manifest_url }}/v{{ version }}/kubevirt.yaml.j2"
-    dest: "{{ kubevirt_template_dir }}/kubevirt.yaml.j2"
-  when: (kubevirt_template.stat.exists == False) and (byo_template.stat.exists == False)
-
-- name: Render KubeVirt template
+- name: Render KubeVirt cr
   template:
-    src: "kubevirt.yaml.j2"
-    dest: "/tmp/kubevirt.yaml"
-  when: kubevirt_template.stat.exists == False
+    src: "kubevirt-cr.yaml.j2"
+    dest: "/tmp/kubevirt-cr.yaml"
+  when: kubevirt_cr.stat.exists == False
 
 - name: Delete apiservices v1alpha2.subresources.kubevirt.io
-  command: "{{ cluster_command }} -n {{ namespace }} delete apiservices v1alpha2.subresources.kubevirt.io"
+  command: "{{ cluster_command }} -n {{ namespace }} delete apiservices v1alpha2.subresources.kubevirt.io --ignore-not-found=true"
 
-- name: Delete KubeVirt Resources
-  command: "{{ cluster_command }} delete -f /tmp/kubevirt.yaml --ignore-not-found=true --wait=false"
+- name: Ask the Operator to cleanup KubeVirt
+  command: "{{ cluster_command }} delete -f /tmp/kubevirt-cr.yaml --ignore-not-found=true"
 
-- name: Wait until {{ namespace }} namespace will dissappear
-  shell: "{{ cluster_command }} get ns {{ namespace }}"
+- name: Wait until virt-api is deleted
+  shell: "{{ cluster_command }} -n {{ namespace }} get deployment | grep virt-api || true"
   register: result
-  until: result.rc != 0
-  retries: 12
+  until: result.stdout == ""
+  retries: 24
   delay: 10
-  ignore_errors: yes
+
+- name: Wait until virt-api is deleted
+  shell: "{{ cluster_command }} -n {{ namespace }} get pods | grep virt-api || true"
+  register: result
+  until: result.stdout == ""
+  retries: 24
+  delay: 10
+
+- name: Wait until virt-controller is deleted
+  shell: "{{ cluster_command }} -n {{ namespace }} get deployment | grep virt-controller || true"
+  register: result
+  until: result.stdout == ""
+  retries: 24
+  delay: 10
+
+- name: Wait until virt-controller is deleted
+  shell: "{{ cluster_command }} -n {{ namespace }} get pods | grep virt-controller || true"
+  register: result
+  until: result.stdout == ""
+  retries: 24
+  delay: 10
+
+- name: Wait until virt-handler is deleted
+  shell: "{{ cluster_command }} -n {{ namespace }} get daemonset | grep virt-handler || true"
+  register: result
+  until: result.stdout == ""
+  retries: 24
+  delay: 10
+
+- name: Wait until virt-handler is deleted
+  shell: "{{ cluster_command }} -n {{ namespace }} get pods | grep virt-handler || true"
+  register: result
+  until: result.stdout == ""
+  retries: 24
+  delay: 10
+
+- name: Check that kubevirt-operator.yaml still exists in /tmp
+  stat:
+    path: "/tmp/kubevirt-operator.yaml"
+  register: kubevirt_template
+
+- name: Render KubeVirt operator template
+  template:
+    src: "kubevirt-operator.yaml.j2"
+    dest: "/tmp/kubevirt-operator.yaml"
+  when: kubevirt_template.stat.exists == False
+
+- name: Delete KubeVirt operator Resources
+  command: "{{ cluster_command }} delete -f /tmp/kubevirt-operator.yaml --ignore-not-found=true"
+
+- name: Wait until virt-operator is deleted
+  shell: "{{ cluster_command }} -n {{ namespace }} get deploy | grep virt-operator || true"
+  register: result
+  until: result.stdout == ""
+  retries: 24
+  delay: 10
+
+- name: Wait until virt-operator is deleted
+  shell: "{{ cluster_command }} -n {{ namespace }} get pods | grep virt-operator || true"
+  register: result
+  until: result.stdout == ""
+  retries: 24
+  delay: 10
+
+- name: Check that kubevirt-config.yaml still exists in /tmp
+  stat:
+    path: "/tmp/kubevirt-config.yaml"
+  register: kubevirt_config
+
+- name: Render KubeVirt cr
+  template:
+    src: "kubevirt-config.yaml"
+    dest: "/tmp/kubevirt-cr.yaml"
+  when: kubevirt_config.stat.exists == False
+
+- name: Delete kubevirt feature gates
+  shell: "{{ cluster_command }} delete -f {{ kubevirt_template_dir }}/kubevirt-config.yaml -n {{ namespace }}"
+
+- name: Delete KubeVirt namespace
+  command: "{{ cluster_command }} delete namespace {{ namespace }} --ignore-not-found=true --wait=false"
+
+- name: Wait until {{ namespace }} namespace dissappears
+  shell: "{{ cluster_command }} get ns {{ namespace }} --ignore-not-found"
+  register: result
+  until: result.stdout == ""
+  retries: 20
+  delay: 10

--- a/roles/kubevirt/tasks/provision.yml
+++ b/roles/kubevirt/tasks/provision.yml
@@ -8,126 +8,59 @@
   shell: "{{ cluster_command }} create namespace {{ namespace }}"
   when: ns.rc != 0
 
-- name: Add Privileged Policy
-  command: "oc adm policy add-scc-to-user privileged -z {{ item }} -n {{ namespace }}"
-  with_items: "{{ kubevirt_privileged_policies | list }}"
-  when: platform=="openshift"
+- name: Render KubeVirt operator
+  template:
+    src: "kubevirt-operator.yaml.j2"
+    dest: "/tmp/kubevirt-operator.yaml"
 
-- name: Add Hostmount-anyuid Policy
-  command: "oc adm policy add-scc-to-user hostmount-anyuid -z kubevirt-infra -n {{ namespace }}"
-  when: platform=="openshift"
+- name: Create KubeVirt Operator
+  command: "{{ cluster_command }} apply -f /tmp/kubevirt-operator.yaml --validate=false"
 
 - name: Enable kubevirt feature gates
   shell: "{{ cluster_command }} apply -f {{ kubevirt_template_dir }}/kubevirt-config.yaml -n {{ namespace }}"
 
-# Kubevirt manifest
-- name: Check for kubevirt.yaml.j2 template in {{ kubevirt_template_dir }}
-  stat:
-    path: "{{ kubevirt_template_dir }}/kubevirt.yaml.j2"
-  register: byo_template
-
-- name: Render kubevirt.yaml.j2 template from  {{ kubevirt_template_dir }}
+- name: Render KubeVirt resources
   template:
-    src: "{{ kubevirt_template_dir }}/kubevirt.yaml.j2"
-    dest: "/tmp/kubevirt.yaml"
-  when: byo_template.stat.exists == true
-
-- name: get kubevirt-manifests from {{ release_manifest_url }}
-  block:
-  - name: Check for kubevirt.yaml.j2 template was downloaded to /tmp
-    stat:
-      path: "/tmp/kubevirt.yaml.j2"
-    register: downloaded_template
-
-  - name: Download KubeVirt Template
-    get_url:
-      url: "{{ release_manifest_url }}/v{{ version }}/kubevirt.yaml.j2"
-      dest: "/tmp/kubevirt.yaml.j2"
-    when: downloaded_template.stat.exists == false
-
-  - name: Render Downloaded KubeVirt Yaml
-    template:
-      src: "/tmp/kubevirt.yaml.j2"
-      dest: "/tmp/kubevirt.yaml"
-
-  when: byo_template.stat.exists == false
+    src: "kubevirt-cr.yaml.j2"
+    dest: "/tmp/kubevirt-cr.yaml"
 
 - name: Create KubeVirt Resources
-  command: "{{ cluster_command }} apply -f /tmp/kubevirt.yaml --validate=false"
+  command: "{{ cluster_command }} apply -f /tmp/kubevirt-cr.yaml --validate=false"
 
-# Skipping because of https://github.com/kubevirt/kubevirt/issues/1628
-- name: Demo Content manifest
-  tags: never
-  block:
-    - name: Check for demo-content.yaml template in {{ kubevirt_template_dir }}
-      stat:
-        path: "{{ kubevirt_template_dir }}/demo-content.yaml"
-      register: byo_demo_content
+- name: Give the kubevirt-operator user privilages
+  command: "{{ cluster_command }} adm policy add-scc-to-user privileged -n {{ namespace }} -z kubevirt-operator"
 
-    - name: Check for demo-content.yaml version v{{ version }} in {{ offline_template_dir }}
-      stat:
-        path: "{{ offline_template_dir }}/v{{ version }}/demo-content.yaml"
-      register: offline_demo_content
-      when: byo_demo_content.stat.exists == False
+- name: Wait until virt-operator is running
+  shell: "{{ cluster_command }} -n {{ namespace }} get deployment | grep virt-operator | awk \'{ if ($2 == $5) print \"0\"; else print \"1\"}\'"
+  register: result
+  until: result.stdout == "0"
+  retries: 24
+  delay: 10
 
-    - name: Download Demo Content
-      get_url:
-        url: "{{ release_manifest_url }}/v{{ version }}/demo-content.yaml"
-        dest: "{{ kubevirt_template_dir }}/demo-content.yaml"
-      when: byo_demo_content.stat.exists == False and offline_demo_content.stat.exists == False
+- name: Wait until virt-api is running
+  shell: "{{ cluster_command }} -n {{ namespace }} get deployment | grep virt-api | awk \'{ if ($2 == $5) print \"0\"; else print \"1\"}\'"
+  register: result
+  until: result.stdout == "0"
+  retries: 24
+  delay: 10
 
-    - name: Copy Offline Demo Content to /tmp
-      copy:
-        src: "{{ offline_template_dir }}/v{{ version }}/demo-content.yaml"
-        dest: "/tmp/demo-content.yaml"
-      when: offline_demo_content is not skipped and offline_demo_content.stat.exists == True
+- name: Wait until virt-controller is running
+  shell: "{{ cluster_command }} -n {{ namespace }} get deployment | grep virt-controller | awk \'{ if ($2 == $5) print \"0\"; else print \"1\"}\'"
+  register: result
+  until: result.stdout == "0"
+  retries: 24
+  delay: 10
 
-    - name: Copy BYO Demo Content to /tmp
-      copy:
-        src: "{{ kubevirt_template_dir }}/demo-content.yaml"
-        dest: "/tmp/demo-content.yaml"
-      when: byo_demo_content.stat.exists == False and (offline_demo_content is skipped or offline_demo_content.stat.exists == False)
+- name: Wait until virt-handler is running
+  shell: "{{ cluster_command }} -n {{ namespace }} get daemonset | grep virt-handler | awk \'{ if ($3 == $4) print \"0\"; else print \"1\"}\'"
+  register: result
+  until: result.stdout == "0"
+  retries: 50
+  delay: 10
 
-    - name: Create Demo Content
-      command: "{{ cluster_command }} apply -f /tmp/demo-content.yaml"
-      when: deploy_demo == true
+- name: Debug vmis
+  command: "{{ cluster_command }} get crds"
+  register: crds
 
-# VM Templates manifests
-- name: install vm templates manifests
-  block:
-  - name: Check for vm templates in {{ kubevirt_template_dir }}
-    stat:
-      path: "{{ kubevirt_template_dir }}/common-templates.yaml"
-    register: byo_vm_templates
-
-  - name: Apply vm templates from {{ kubevirt_template_dir }}/common-templates.yaml
-    command: "{{ cluster_command }} apply -f {{ kubevirt_template_dir }}/common-templates.yaml"
-    when: byo_vm_templates.stat.exists == true
-
-  - name: Download KubeVirt VM templates
-    block:
-      - name: Download KubeVirt default VM templates for version < 0.6.0
-        get_url:
-          url: "https://raw.githubusercontent.com/kubevirt/kubevirt/v{{ version }}/cluster/examples/{{ item }}.yaml"
-          dest: "/tmp/{{ item }}.yaml"
-        with_items:
-          - "{{ default_vm_templates }}"
-        when: "version is version('0.6.0', '<')"
-
-      - name: Create default VM templates in OpenShift Namespace for version < 0.6.0
-        shell: "oc apply -f /tmp/{{ item }}.yaml -n openshift"
-        with_items:
-          - "{{ default_vm_templates }}"
-        when: "version is version('0.6.0', '<')"
-
-      - name: Download KubeVirt default VM templates for version >= 0.6.0
-        get_url:
-          url: "https://github.com/kubevirt/common-templates/releases/download/v{{ common_templates_version }}/common-templates-v{{ common_templates_version }}.yaml"
-          dest: "/tmp/common-templates-v{{ common_templates_version }}.yaml"
-        when: "version is version('0.6.0', '>=')"
-
-      - name: Create default VM templates in OpenShift Namespace for version >= 0.6.0
-        shell: "oc apply -f /tmp/common-templates-v{{ common_templates_version }}.yaml -n openshift"
-        when: "version is version('0.6.0', '>=')"
-    when: byo_vm_templates.stat.exists == false
-  when: platform == "openshift"
+- debug:
+    var: crds.stdout

--- a/roles/kubevirt/templates/.gitignore
+++ b/roles/kubevirt/templates/.gitignore
@@ -3,3 +3,5 @@
 # Except this file
 !.gitignore
 !kubevirt-config.yaml
+!kubevirt-operator.yaml.j2
+!kubevirt-cr.yaml.j2

--- a/roles/kubevirt/templates/kubevirt-cr.yaml.j2
+++ b/roles/kubevirt/templates/kubevirt-cr.yaml.j2
@@ -1,0 +1,8 @@
+---
+apiVersion: kubevirt.io/v1alpha2
+kind: KubeVirt
+metadata:
+  name: kubevirt
+  namespace: {{ namespace }}
+spec:
+  imagePullPolicy: {{ image_pull_policy }}

--- a/roles/kubevirt/templates/kubevirt-operator.yaml.j2
+++ b/roles/kubevirt/templates/kubevirt-operator.yaml.j2
@@ -1,0 +1,127 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    operator.kubevirt.io: ""
+  name: kubevirts.kubevirt.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  - JSONPath: .status.phase
+    name: Phase
+    type: string
+  group: kubevirt.io
+  names:
+    kind: KubeVirt
+    plural: kubevirts
+    shortNames:
+    - kv
+    - kvs
+    singular: kubevirt
+  scope: Namespaced
+  version: v1alpha2
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubevirt.io:operator
+  labels:
+    operator.kubevirt.io: ""
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - kubevirts
+    verbs:
+      - get
+      - delete
+      - create
+      - update
+      - patch
+      - list
+      - watch
+      - deletecollection
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: kubevirt-operator
+  namespace: {{ namespace }}
+  labels:
+    operator.kubevirt.io: ""
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubevirt-operator
+  namespace: {{ namespace }}
+  labels:
+    operator.kubevirt.io: ""
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: kubevirt-operator
+    namespace: {{ namespace }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: virt-operator
+  namespace: {{ namespace }}
+  labels:
+    operator.kubevirt.io: "virt-operator"
+spec:
+  replicas: 1
+  selector:
+      matchLabels:
+        operator.kubevirt.io: virt-operator
+  template:
+    metadata:
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+        scheduler.alpha.kubernetes.io/tolerations: |
+                  [
+                    {
+                      "key": "CriticalAddonsOnly",
+                      "operator": "Exists"
+                    }
+                  ]
+      labels:
+        operator.kubevirt.io: virt-operator
+        prometheus.kubevirt.io: ""
+    spec:
+      serviceAccountName: kubevirt-operator
+      containers:
+        - name: virt-operator
+          image: &image {{ docker_prefix }}/virt-operator:{{ docker_tag }}
+          imagePullPolicy: {{ image_pull_policy }}
+          command:
+            - virt-operator
+            - --port
+            - "8443"
+            - -v
+            - "2"
+          ports:
+            - containerPort: 8443
+              name: "metrics"
+              protocol: "TCP"
+          readinessProbe:
+            httpGet:
+              scheme: HTTPS
+              port: "metrics"
+              path: "/metrics"
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          env:
+            - name: OPERATOR_IMAGE
+              value: *image
+      securityContext:
+        runAsNonRoot: true

--- a/vars/all.yml
+++ b/vars/all.yml
@@ -8,7 +8,7 @@ openshift_ansible_dir: "openshift-ansible/"
 openshift_playbook_path: "{{ openshift_ansible_dir }}/{{ 'playbooks/byo/config.yml' if kubevirt_openshift_version == '3.7' else 'playbooks/deploy_cluster.yml' }}"
 
 ### KubeVirt ###
-version: 0.12.0-alpha.2
+version: 0.12.0
 image_pull_policy: IfNotPresent
 deploy_demo: true
 


### PR DESCRIPTION
Use Ansible to orchestrate deployment while OLM continues to develop.

This PR will break CI until operator PRs merge:
  - https://github.com/kubevirt/kubevirt/pull/1860
  - https://github.com/kubevirt/kubevirt/pull/1803
  - https://github.com/kubevirt/containerized-data-importer/pull/579

(cherry picked from commit 3f57e5a8e3f71ecfb784cb15e107ef084687266d)

```release-note
Install KubeVirt with an operator
```
