### PR TITLE
add role and playbook to deploy kubevirt-metrics-collector

### DIFF
--- a/playbooks/kubevirt.yml
+++ b/playbooks/kubevirt.yml
@@ -25,3 +25,7 @@
 # Deploy kubevirt ssp
 - import_playbook: kubevirt-ssp.yml
   when: platform == "openshift"
+
+# Optionally deploy the metrics collector
+- import_playbook: kubevirt_metrics_collector.yml
+  when: platform == "openshift"

--- a/playbooks/kubevirt_metrics_collector.yml
+++ b/playbooks/kubevirt_metrics_collector.yml
@@ -1,0 +1,11 @@
+---
+- import_playbook: initial_configuration.yml
+
+- name: Deploy kubevirt_metrics_collector role
+  hosts: localhost
+  connection: local
+  gather_facts: False
+  environment:
+    http_proxy: ""
+  roles:
+    - role: "kubevirt_metrics_collector"

--- a/roles/kubevirt_metrics_collector/README.md
+++ b/roles/kubevirt_metrics_collector/README.md
@@ -1,0 +1,5 @@
+# kubevirt_metrics_collector
+
+Deploys a kubevirt DS to export metrics to prometheus
+about the infrastructural processes running into VM pods.
+Optional, depending on variables set.

--- a/roles/kubevirt_metrics_collector/defaults/main.yml
+++ b/roles/kubevirt_metrics_collector/defaults/main.yml
@@ -1,0 +1,14 @@
+---
+kubevirt_metrics_collector_namespace: "openshift-monitoring"
+kubevirt_metrics_collector_files_dir: "{{ role_path }}/templates"
+cluster_command: "oc" # in case the roles/playbook is not executed from kubevirt.yml
+registry_url: "docker.io"
+registry_namespace: "fromanirh"
+docker_prefix: "{{ registry_url }}/{{ registry_namespace }}"
+image_name: "kubevirt-metrics-collector"
+image_version: 0.12.0.5
+docker_tag: "v{{ image_version }}"
+image_pull_policy: IfNotPresent
+platform: "openshift"
+apb_action: "provision"
+kubevirt_metrics_collector_enabled: false

--- a/roles/kubevirt_metrics_collector/tasks/deprovision.yml
+++ b/roles/kubevirt_metrics_collector/tasks/deprovision.yml
@@ -1,0 +1,41 @@
+---
+- name: Check that kubevirt_metrics_collector_scc.yaml still exists in /tmp
+  stat:
+    path: "/tmp/kubevirt_metrics_collector_scc.yaml"
+  register: kubevirt_metrics_collector
+  when: kubevirt_metrics_collector_enabled
+
+- name: Copy kubevirt_metrics_collector_scc.yaml to temp directory
+  template:
+    src: "{{ kubevirt_metrics_collector_files_dir }}/kubevirt_metrics_collector_scc.yaml"
+    dest: "/tmp/kubevirt_metrics_collector_scc.yaml"
+  when: kubevirt_metrics_collector_enabled and kubevirt_metrics_collector.stat.exists == false
+
+- name: Check that kubevirt_metrics_collector_ds.yaml still exists in /tmp
+  stat:
+    path: "/tmp/kubevirt_metrics_collector.yaml"
+  register: kubevirt_metrics_collector_ds
+  when: kubevirt_metrics_collector_enabled
+
+- name: Copy kubevirt_metrics_collector_ds.yaml to temp directory
+  template:
+    src: "{{ kubevirt_metrics_collector_files_dir }}/kubevirt_metrics_collector_ds.yaml"
+    dest: "/tmp/kubevirt_metrics_collector_ds.yaml"
+  when: kubevirt_metrics_collector_enabled and kubevirt_metrics_collector_ds.stat.exists == false
+
+- name: Delete kubevirt_metrics_collector_scc
+  shell: "{{ cluster_command }} delete --ignore-not-found -f /tmp/kubevirt_metrics_collector_scc.yaml -n {{ kubevirt_metrics_collector_namespace }}"
+  when: kubevirt_metrics_collector_enabled
+
+- name: Delete kubevirt_metrics_collector_ds
+  shell: "{{ cluster_command }} delete --ignore-not-found -f /tmp/kubevirt_metrics_collector_ds.yaml -n {{ kubevirt_metrics_collector_namespace }}"
+  when: kubevirt_metrics_collector_enabled
+
+- name: Wait until kubevirt_metrics_collector deamonset is deleted
+  shell: "{{ cluster_command }} -n {{ kubevirt_metrics_collector_namespace }} get ds | grep -o -E kubevirt_metrics_collector | wc -l"
+  register: result
+  until: result.stdout == "0"
+  retries: 24
+  delay: 10
+  when: kubevirt_metrics_collector_enabled
+

--- a/roles/kubevirt_metrics_collector/tasks/main.yml
+++ b/roles/kubevirt_metrics_collector/tasks/main.yml
@@ -1,0 +1,1 @@
+- include_tasks: "{{ apb_action }}.yml"

--- a/roles/kubevirt_metrics_collector/tasks/provision.yml
+++ b/roles/kubevirt_metrics_collector/tasks/provision.yml
@@ -1,0 +1,44 @@
+---
+- name: Check that kubevirt_metrics_collector_scc.yaml still exists in /tmp
+  stat:
+    path: "/tmp/kubevirt_metrics_collector_scc.yaml"
+  register: kubevirt_metrics_collector_scc
+  when: kubevirt_metrics_collector_enabled
+
+- name: Copy kubevirt_metrics_collector_scc.yaml to temp directory
+  template:
+    src: "{{ kubevirt_metrics_collector_files_dir }}/kubevirt_metrics_collector_scc.yaml"
+    dest: "/tmp/kubevirt_metrics_collector_scc.yaml"  
+  when: kubevirt_metrics_collector_enabled and kubevirt_metrics_collector_scc.stat.exists == false
+
+- name: Check that kubevirt_metrics_collector.yaml still exists in /tmp
+  stat:
+    path: "/tmp/kubevirt_metrics_collector.yaml"
+  register: kubevirt_metrics_collector_ds
+  when: kubevirt_metrics_collector_enabled
+
+- name: Copy kubevirt_metrics_collector.yaml to temp directory
+  template:
+    src: "{{ kubevirt_metrics_collector_files_dir }}/kubevirt_metrics_collector_ds.yaml"
+    dest: "/tmp/kubevirt_metrics_collector_ds.yaml"  
+  when: kubevirt_metrics_collector_enabled and kubevirt_metrics_collector_ds.stat.exists == false
+
+- name: Create kubevirt_metrics_collector_scc
+  shell: "{{ cluster_command }} create -f /tmp/kubevirt_metrics_collector_scc.yaml -n {{ kubevirt_metrics_collector_namespace }}"
+  when: kubevirt_metrics_collector_enabled
+
+- name: Fixing permissions for kubevirt_metrics_collector_scc
+  shell: "{{ cluster_command }} patch scc scc-hostpath -p '{\"allowHostPID\": true}' && {{ cluster_command }}  patch scc scc-hostpath -p '{\"allowHostDirVolumePlugin\": true}'"
+
+- name: Create kubevirt_metrics_collector
+  shell: "{{ cluster_command }} create -f /tmp/kubevirt_metrics_collector_ds.yaml -n {{ kubevirt_metrics_collector_namespace }}"
+  when: kubevirt_metrics_collector_enabled
+
+- name: Wait until kubevirt_metrics_collector deamonset is created
+  shell: "{{ cluster_command }} -n {{ kubevirt_metrics_collector_namespace }} get ds | grep -o -E kubevirt-metrics-collector | wc -l"
+  register: result
+  until: result.stdout == "1"
+  retries: 24
+  delay: 10
+  when: kubevirt_metrics_collector_enabled
+

--- a/roles/kubevirt_metrics_collector/templates/kubevirt_metrics_collector_ds.yaml
+++ b/roles/kubevirt_metrics_collector/templates/kubevirt_metrics_collector_ds.yaml
@@ -40,7 +40,7 @@ spec:
       serviceAccountName: kubevirt-metrics-collector
       hostPID: true
       nodeSelector:
-        node-role.kubernetes.io/infra: "true"
+        node-role.kubernetes.io/compute: "true"
       containers:
       - name: collector
         args:

--- a/roles/kubevirt_metrics_collector/templates/kubevirt_metrics_collector_ds.yaml
+++ b/roles/kubevirt_metrics_collector/templates/kubevirt_metrics_collector_ds.yaml
@@ -1,0 +1,82 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: kubevirt-metrics-config
+data:
+  collector.conf: |-
+    {
+      "criendpoint": "unix:///var/run/dockershim.sock",
+      "listenaddress": ":9100",
+      "interval": "5s",
+      "targets": [{
+        "name": "libvirt",
+        "argv": ["/usr/sbin/libvirtd*"]
+      }, {
+        "name": "qemu",
+        "argv": ["/usr/*/qemu*"]
+      }]
+    }
+
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: kubevirt-metrics-collector
+  labels:
+    app: kubevirt-metrics-collector
+spec:
+  template:
+    metadata:
+      labels:
+        name: kubevirt-metrics-collector
+        vmi.prometheus.kubevirt.io: ""
+        k8s-app: node-exporter
+        app: node-exporter
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9100"
+    spec:
+      serviceAccountName: kubevirt-metrics-collector
+      hostPID: true
+      nodeSelector:
+        node-role.kubernetes.io/infra: "true"
+      containers:
+      - name: collector
+        args:
+        - --cert-file=/etc/tls/private/tls.crt
+        - --key-file=/etc/tls/private/tls.key
+        - /etc/kubevirt-metrics-collector/config.json
+        ports:
+        - containerPort: 9100
+          protocol: "TCP"
+          name: "https"
+        image: {{ registry_namespace }}/{{ image_name }}:v0.12.0.5
+        imagePullPolicy: {{ image_pull_policy }}
+        volumeMounts:
+        - name: kubevirt-metrics-config
+          mountPath: /etc/kubevirt-metrics-collector
+        - name: cri-runtime
+          mountPath: /var/run/dockershim.sock
+        - name: node-exporter-tls
+          mountPath: /etc/tls/private
+        env:
+        - name: KUBE_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+      volumes:
+      - name: kubevirt-metrics-config
+        configMap:
+          name: kubevirt-metrics-config
+          items:
+          - key: collector.conf
+            path: config.json
+      - name: cri-runtime
+        hostPath:
+          path: /var/run/dockershim.sock
+      - name: node-exporter-tls
+        secret:
+          defaultMode: 420
+          secretName: node-exporter-tls
+

--- a/roles/kubevirt_metrics_collector/templates/kubevirt_metrics_collector_scc.yaml
+++ b/roles/kubevirt_metrics_collector/templates/kubevirt_metrics_collector_scc.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubevirt-metrics-collector
+  labels:
+    kubevirt.io: ""
+---
+kind: SecurityContextConstraints
+apiVersion: v1
+metadata:
+  name: scc-hostpath
+allowPrivilegedContainer: true
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+fsGroup:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+users:
+- system:serviceaccount:{{ kubevirt_metrics_collector_namespace }}:kubevirt-metrics-collector
+volumes:
+- hostPath
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Add automation to deploy kubevirt-metrics-collector. This is an *optional* component to have additional metrics about the behaviour of the infrastructure process which allow to run VMs. For example, libvirtd and qemu.

Most administators will probably don't need or care about the metrics this component exposes.
For this reason the provisioning and deprovisioning are controlled by a variable, which is turned to false by default.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
kubevirt-metrics-collector is an official, albeit optional, component of kubevirt. Unfortunately the integration with openshift is still experimental. Nevertheless, we use this PR to laid the foundations of the automation

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support to optionally deploy kubevirt-metrics-collector
```
