### PR TITLE
Only run ovs tasts when it's enabled

### DIFF
--- a/roles/network-multus/tasks/deprovision.yml
+++ b/roles/network-multus/tasks/deprovision.yml
@@ -21,9 +21,11 @@
   template:
     src: cni-plugins.yml
     dest: /tmp/cni-plugins.yml
+  when: deploy_cni_plugins
 
 - name: Delete cni plugins Resources
   command: "{{ cluster_command }} delete -f /tmp/cni-plugins.yml --ignore-not-found"
+  when: deploy_cni_plugins
 
 - name: Render OVS plugin deployment yaml
   template:


### PR DESCRIPTION
In the deprovision task, only run the ovs tasks when its enabled.

```release-note
None
```
