### PR TITLE
Add sleep container in cpu-node-labeller to prevent  restarting

### DIFF
--- a/roles/kubevirt-cpu-node-labeller/tasks/deprovision.yml
+++ b/roles/kubevirt-cpu-node-labeller/tasks/deprovision.yml
@@ -1,14 +1,8 @@
 ---
-- name: Check that kubevirt-cpu-node-labeller.yaml still exists in /tmp
-  stat:
-    path: "/tmp/kubevirt-cpu-node-labeller.yaml"
-  register: kubevirt_cpu_node_labeller
-
 - name: Copy kubevirt-cpu-node-labeller yaml to temp directory
   template:
     src: "{{ kubevirt_cpu_node_labeller_files_dir }}/kubevirt-cpu-node-labeller-0.0.1.yaml"
     dest: "/tmp/kubevirt-cpu-node-labeller.yaml"  
-  when: kubevirt_cpu_node_labeller.stat.exists == false
 
 - name: Delete Kubevirt cpu-node-labeller
   shell: "{{ cluster_command }} delete --ignore-not-found -f /tmp/kubevirt-cpu-node-labeller.yaml -n {{ kubevirt_node_labeller_namespace }}"

--- a/roles/kubevirt-cpu-node-labeller/tasks/provision.yml
+++ b/roles/kubevirt-cpu-node-labeller/tasks/provision.yml
@@ -1,14 +1,8 @@
 ---
-- name: Check that kubevirt-cpu-node-labeller.yaml still exists in /tmp
-  stat:
-    path: "/tmp/kubevirt-cpu-node-labeller.yaml"
-  register: kubevirt_cpu_node_labeller
-
 - name: Copy kubevirt-cpu-node-labeller.yaml to temp directory
   template:
     src: "{{ kubevirt_cpu_node_labeller_files_dir }}/kubevirt-cpu-node-labeller-0.0.1.yaml"
     dest: "/tmp/kubevirt-cpu-node-labeller.yaml"  
-  when: kubevirt_cpu_node_labeller.stat.exists == false
 
 - name: Create kubevirt-cpu-node-labeller
   shell: "{{ cluster_command }} create -f /tmp/kubevirt-cpu-node-labeller.yaml -n {{ kubevirt_node_labeller_namespace }}"

--- a/roles/kubevirt-cpu-node-labeller/templates/kubevirt-cpu-node-labeller-0.0.1.yaml
+++ b/roles/kubevirt-cpu-node-labeller/templates/kubevirt-cpu-node-labeller-0.0.1.yaml
@@ -56,16 +56,10 @@ spec:
     spec:
       serviceAccount: kubevirt-cpu-node-labeller
       containers:
-        - env:
-          - name: NODE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          image: {{ docker_prefix }}/kubevirt-cpu-node-labeller:{{ docker_tag }}
-          name: kubevirt-cpu-node-labeller
-          volumeMounts:
-            - name: nfd-source
-              mountPath: "/etc/kubernetes/node-feature-discovery/source.d/"
+      - name: kubevirt-cpu-node-labeller-sleeper
+        image: {{ docker_prefix }}/kubevirt-cpu-node-labeller:{{ docker_tag }}
+        command: ["sleep"]
+        args: ["infinity"]
       initContainers:
         - image: {{ docker_prefix }}/kubevirt-cpu-model-nfd-plugin:{{ docker_tag }}
           command: ["/bin/sh","-c"]
@@ -88,6 +82,16 @@ spec:
               devices.kubevirt.io/kvm: "1"
             limits:
               devices.kubevirt.io/kvm: "1"
+          volumeMounts:
+            - name: nfd-source
+              mountPath: "/etc/kubernetes/node-feature-discovery/source.d/"
+        - env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          image: {{ docker_prefix }}/kubevirt-cpu-node-labeller:{{ docker_tag }}
+          name: kubevirt-cpu-node-labeller
           volumeMounts:
             - name: nfd-source
               mountPath: "/etc/kubernetes/node-feature-discovery/source.d/"


### PR DESCRIPTION
**What this PR does / why we need it**:
Moved cpu-node-labeller into initContainers. Added second cpu-node-labeller into containers to sleep infinity and to hold pod running (so it is not restarted again and again), because when daemonset pod finishes, it is restarted everytime it finishes (restartPolicy can't be turned off for daemonset pods).

**Release note**:
```release-note
NONE
```
