### PR TITLE
changed oc create to oc apply in kubevirt-cpu-node-labeller

### DIFF
--- a/roles/kubevirt-cpu-node-labeller/tasks/provision.yml
+++ b/roles/kubevirt-cpu-node-labeller/tasks/provision.yml
@@ -5,7 +5,7 @@
     dest: "/tmp/kubevirt-cpu-node-labeller.yaml"  
 
 - name: Create kubevirt-cpu-node-labeller
-  shell: "{{ cluster_command }} create -f /tmp/kubevirt-cpu-node-labeller.yaml -n {{ kubevirt_node_labeller_namespace }}"
+  shell: "{{ cluster_command }} apply -f /tmp/kubevirt-cpu-node-labeller.yaml -n {{ kubevirt_node_labeller_namespace }}"
 
 - name: Wait until kubevirt-cpu-node-labeller deamonset is created
   shell: "{{ cluster_command }} -n {{ kubevirt_node_labeller_namespace }} get ds | grep -o -E kubevirt-cpu-node-labeller | wc -l"


### PR DESCRIPTION
**What this PR does / why we need it**:
changed oc create to oc apply.
oc create throws error when user tries to run ansible twice, oc apply updates it without error

**Release note**:
```release-note
NONE
```
