### PR TITLE
change cdi-uploadproxy route name

### DIFF
--- a/roles/cdi/templates/cdi-uploadproxy-route.yaml.j2
+++ b/roles/cdi/templates/cdi-uploadproxy-route.yaml.j2
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Route
 metadata:
-  name: cdi-uploadproxy-route
+  name: cdi-uploadproxy
   namespace: {{ cdi_namespace }}
 spec:
   to:
@@ -10,4 +10,3 @@ spec:
     name: cdi-uploadproxy
   tls:
     termination: passthrough
-   


### PR DESCRIPTION
**What this PR does / why we need it**:
changed route name to cdi-uploadproxy, in order to be consistent with system naming

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
