### PR TITLE
Deprovision sriov resources

### DIFF
--- a/roles/network-multus/tasks/deprovision.yml
+++ b/roles/network-multus/tasks/deprovision.yml
@@ -25,6 +25,40 @@
 - name: Delete cni plugins Resources
   command: "{{ cluster_command }} delete -f /tmp/cni-plugins.yml --ignore-not-found"
 
+# note: this rule does NOT delete /etc/pcidp/config.json file because k8s
+# doesn't support finalizers to clean up mounted directory
+- name: Uninstall SR-IOV device plugin
+  block:
+  - name: Render SR-IOV DP deployment yaml
+    template:
+      src: sriovdp.yml
+      dest: /tmp/sriovdp.yml
+
+  - name: Delete SR-IOV DP resources
+    shell: "{{ cluster_command }} delete -f /tmp/sriovdp.yml --ignore-not-found"
+
+- name: Uninstall SR-IOV CNI plugin
+  block:
+  - name: Render SR-IOV CNI deployment yaml
+    template:
+      src: sriov-cni.yml
+      dest: /tmp/sriov-cni.yml
+
+  - name: Delete SR-IOV CNI resources
+    shell: "{{ cluster_command }} delete -f /tmp/sriov-cni.yml --ignore-not-found"
+
+- name: Uninstall SR-IOV network
+  block:
+  - name: Render SR-IOV network CRD yaml
+    template:
+      src: sriov-crd.yml
+      dest: /tmp/sriov-crd.yml
+
+  - name: Delete SR-IOV network CRD
+    shell: "{{ cluster_command }} delete -f /tmp/sriov-crd.yml --ignore-not-found"
+    # ignore in case when crd is not known
+    ignore_errors: yes
+
 - name: Render OVS plugin deployment yaml
   template:
     src: ovs-cni.yml

--- a/roles/network-multus/tasks/deprovision.yml
+++ b/roles/network-multus/tasks/deprovision.yml
@@ -33,9 +33,9 @@
     template:
       src: sriovdp.yml
       dest: /tmp/sriovdp.yml
-
   - name: Delete SR-IOV DP resources
     shell: "{{ cluster_command }} delete -f /tmp/sriovdp.yml --ignore-not-found"
+  when: deploy_sriov_plugin
 
 - name: Uninstall SR-IOV CNI plugin
   block:
@@ -43,9 +43,9 @@
     template:
       src: sriov-cni.yml
       dest: /tmp/sriov-cni.yml
-
   - name: Delete SR-IOV CNI resources
     shell: "{{ cluster_command }} delete -f /tmp/sriov-cni.yml --ignore-not-found"
+  when: deploy_sriov_plugin
 
 - name: Uninstall SR-IOV network
   block:
@@ -53,11 +53,11 @@
     template:
       src: sriov-crd.yml
       dest: /tmp/sriov-crd.yml
-
   - name: Delete SR-IOV network CRD
     shell: "{{ cluster_command }} delete -f /tmp/sriov-crd.yml --ignore-not-found"
     # ignore in case when crd is not known
     ignore_errors: yes
+  when: deploy_sriov_plugin
 
 - name: Render OVS plugin deployment yaml
   template:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: delete SR-IOV resources on deprovisioning. The only piece that is not cleaned up is /etc/pcidp because I don't know how to do it easily without running a new container that would delete the directory, on all cluster nodes, which seems like overkill.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
