### PR TITLE
WebUI: fix incorrect set_fact in deprovision

### DIFF
--- a/roles/kubevirt_web_ui/tasks/deprovision.web-ui.yml
+++ b/roles/kubevirt_web_ui/tasks/deprovision.web-ui.yml
@@ -1,6 +1,5 @@
 ---
-- name: Set empty version to deprovision the Web UI
-  set_fact: kubevirt_web_ui_version=""
+# The kubevirt_web_ui_version_effective is expected to be empty string ("") - see main.yml
 
 - include_tasks: provision.web-ui.yml
 

--- a/roles/kubevirt_web_ui/tasks/main.yml
+++ b/roles/kubevirt_web_ui/tasks/main.yml
@@ -1,12 +1,16 @@
 ---
 - name: Deprovision Web UI and its operator
   block:
+    - name: Set empty version to deprovision the Web UI
+      set_fact: kubevirt_web_ui_version_effective=""
     - include_tasks: "deprovision.web-ui.yml"
     - include_tasks: "deprovision.operator.yml"
   when: apb_action == "deprovision"
 
 - name: Provision Web UI via operator
   block:
+    - name: "Use '{{ kubevirt_web_ui_version }}' KubeVirt Web UI version to provision"
+      set_fact: kubevirt_web_ui_version_effective="{{ kubevirt_web_ui_version }}"
     - include_tasks: "provision.operator.yml"
     - include_tasks: "provision.web-ui.yml"
   when: apb_action != "deprovision"

--- a/roles/kubevirt_web_ui/tasks/provision.web-ui.yml
+++ b/roles/kubevirt_web_ui/tasks/provision.web-ui.yml
@@ -14,11 +14,11 @@
       copy:
         src: "{{ files_dir }}/crds/kubevirt_v1alpha1_kwebui_cr.yaml"
         dest: "{{ mktemp.stdout }}/cr.yaml"
-    - name: Set kubevirt-web-ui version
+    - name: "Set kubevirt-web-ui version: '{{ kubevirt_web_ui_version_effective | default(kubevirt_web_ui_version) }}'"
       lineinfile:
         path: "{{ mktemp.stdout }}/cr.yaml"
         regexp: "^  version:.*$"
-        line: "  version: {{ kubevirt_web_ui_version }}"
+        line: "  version: {{ kubevirt_web_ui_version_effective | default(kubevirt_web_ui_version) }}"
     - name: Set kubevirt-web-ui registry_url
       lineinfile:
         path: "{{ mktemp.stdout }}/cr.yaml"
@@ -51,13 +51,13 @@
 
 # For details about the error, see logs of the operator pod
 # Example:  oc logs kubevirt-web-ui-operator-6dd9547864-pdcx5 -n kubevirt-web-ui
-- name: Wait until Web UI is ready
+- name: "Wait until Web UI is ready: '{{ kubevirt_web_ui_version_effective }}'"
   shell: "{{ cluster_command }} -n {{ kubevirt_web_ui_namespace }} get KWebUI kubevirt-web-ui -o yaml | grep -q 'phase: PROVISIONED' && echo -n DONE"
   register: result
   until: result.stdout == "DONE"
   retries: 30
   delay: 10
-  when: kubevirt_web_ui_version != ""
+  when: kubevirt_web_ui_version_effective != ""
 
 # The Web UI is deprovisioned either when
 #   - KWebUI CR is missing
@@ -69,5 +69,5 @@
   until: result.stdout == "MISSING" or result.stdout == "NOT_DEPLOYED"
   retries: 30
   delay: 10
-  when: kubevirt_web_ui_version == ""
+  when: kubevirt_web_ui_version_effective == ""
 


### PR DESCRIPTION
The deprovision.web-ui tasks reuse the provision flow by setting
desired KubeVirt Web UI version to an empty string ("").

Prior this fix, the setting was attempted to be done via set_fact
to an existing environment value. Anyway, this was incorrect due
to precedence of parameters in Ansible.

This patch fixes the bug by setting the desired version reliably.

**What this PR does / why we need it**: Fix of [BZ 1665391](https://bugzilla.redhat.com/show_bug.cgi?id=1665391) - incorrect use of set_fact of env variable

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes: [BZ 1665391](https://bugzilla.redhat.com/show_bug.cgi?id=1665391)

**Special notes for your reviewer**:
This fix is needs to be backported to 1.4.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BZ 1665391 Fix - proper countdown for Web UI deprovision
```
