### PR TITLE
Change cni-plugins image to kubevirt/cni-default-plugins

### DIFF
--- a/roles/network-multus/defaults/main.yml
+++ b/roles/network-multus/defaults/main.yml
@@ -7,7 +7,7 @@ multus_provisioner_name: "kube-multus-amd64"
 multus_provisioner_repo: "docker.io/nfvpe/multus"
 multus_provisioner_release: "snapshot"
 
-cni_provisioner_repo: "quay.io/schseba/cni-plugins"
+cni_provisioner_repo: "quay.io/kubevirt/cni-default-plugins"
 cni_provisioner_name: "kube-cni-plugins-amd64"
 cni_provisioner_release: "latest"
 

--- a/roles/network-multus/templates/cni-plugins.yml
+++ b/roles/network-multus/templates/cni-plugins.yml
@@ -24,6 +24,13 @@ spec:
       containers:
       - name: cni-plugins
         image: {{ cni_provisioner_repo }}:{{ cni_provisioner_release }}
+        command:
+        - /bin/bash
+        - -c
+        - |
+          cp -rf /usr/src/containernetworking/plugins/bin/* /opt/cni/bin/
+          echo "Entering sleep... (success)"
+          sleep infinity
         resources:
           requests:
             cpu: "100m"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Change cni-plugins image to kubevirt/cni-default-plugins

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Upload the cni plugins image to the kubevirt organisation in quay

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt-ansible/603)
<!-- Reviewable:end -->
