### PR TITLE
kubevirt-web-ui: Grant provider privileges to apply manipulate CRDs

### DIFF
--- a/roles/kubevirt_web_ui/files/role.yaml
+++ b/roles/kubevirt_web_ui/files/role.yaml
@@ -65,6 +65,7 @@ metadata:
 rules:
 - apiGroups:
   - oauth.openshift.io
+  - apiextensions.k8s.io
   resources:
   - '*'
   verbs:


### PR DESCRIPTION
The kubevirt-web-ui-operator can manipulate with CRDs.

**What this PR does / why we need it**: Grants kubevirt-web-ui operator service account to manipulate with CRDs

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The kubevirt-web-ui service account can newly create CRDs.
```
