### PR TITLE
Grant kubevirt-web-ui-operator role to manage configmaps in kube-public

### DIFF
--- a/roles/kubevirt_web_ui/files/role_binding_kube-public.yaml
+++ b/roles/kubevirt_web_ui/files/role_binding_kube-public.yaml
@@ -1,0 +1,14 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kubevirt-web-ui-operator
+  namespace: kube-public
+subjects:
+- kind: ServiceAccount
+  name: kubevirt-web-ui-operator
+  namespace: {{ kubevirt_web_ui_namespace }}
+roleRef:
+  kind: Role
+  name: kubevirt-web-ui-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/roles/kubevirt_web_ui/files/role_kube-public.yaml
+++ b/roles/kubevirt_web_ui/files/role_kube-public.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: kubevirt-web-ui-operator
+  namespace: kube-public
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - "*"

--- a/roles/kubevirt_web_ui/tasks/provision.operator.yml
+++ b/roles/kubevirt_web_ui/tasks/provision.operator.yml
@@ -37,6 +37,15 @@
 - name: Add roles
   shell: "{{ cluster_command }} apply -f {{ files_dir }}/role.yaml"
 
+- name: Add roles to access kube-public
+  block:
+  - name: Render roles for kube-public
+    template:
+      src: "{{ files_dir }}/role_kube-public.yaml"
+      dest: "{{ mktemp.stdout }}/role_kube-public.yaml"
+  - name: Apply roles for kube-public
+    shell: "{{ cluster_command }} apply -f {{ mktemp.stdout }}/role_kube-public.yaml"
+
 - name: Add roles to access openshift-console
   block:
   - name: Render roles bindings for openshift-console
@@ -65,6 +74,15 @@
   - name: Apply role bindings for openshift-console
     shell: "{{ cluster_command }} apply -f {{ mktemp.stdout }}/role_binding_extra_for_console.yaml"
   when: ns_console != ""
+
+- name: Add role bindings for kube-public
+  block:
+  - name: Render role bindings for kube-public
+    template:
+      src: "{{ files_dir }}/role_binding_kube-public.yaml"
+      dest: "{{ mktemp.stdout }}/role_binding_kube-public.yaml"
+  - name: Apply role bindings for kube-public
+    shell: "{{ cluster_command }} apply -f {{ mktemp.stdout }}/role_binding_kube-public.yaml"
 
 - name: Add Custom Resource Definition for operator
   shell: "{{ cluster_command }} apply -f {{ files_dir }}/crds/kubevirt_v1alpha1_kwebui_crd.yaml"


### PR DESCRIPTION
Used for create/update of vmware-to-kubevirt operating ssystem ID mapping
table implemented as a configmap.

**What this PR does / why we need it**:
A role for managing configmaps in kube-public is added to the `kubevirt-web-ui` service account.
The operator needs this access to create/update the vmware-to-kubevirt operating system IDs mapping table implemented as a config map.

**Special notes for your reviewer**:
Required by: 
- https://github.com/kubevirt/web-ui-operator/pull/28
- https://github.com/kubevirt/web-ui-components/pull/249

**Release note**:
```release-note
The kubevirt-web-ui service account can newly manage configmaps in kube-public.
```
