### PR TITLE
master + nodes, increae the number of vcpus to 4

### DIFF
--- a/playbooks/provider/lago/LagoInitFile.yml.j2
+++ b/playbooks/provider/lago/LagoInitFile.yml.j2
@@ -19,6 +19,7 @@ host-settings: &nodes-settings
     groups: [nodes]
 {% endif %}
     memory: 4096
+    vcpu: 4
     disks:
       - template_name: {{ lago_vm_image }}
         type: template
@@ -49,6 +50,7 @@ domains:
     groups: [masters, nodes, etcd, nfs]
 {% endif %}
     memory: 4096
+    vcpu: 4
     nics:
       - ip: 192.168.200.2
         net: lago-management-network


### PR DESCRIPTION
The default number of vcpus is 2, which isn't enough for our use case.

Signed-off-by: gbenhaim <galbh2@gmail.com>

```release-note
None
```
