### PR TITLE
Fix curlReq redeclared issue

### DIFF
--- a/tests/network_migration_test.go
+++ b/tests/network_migration_test.go
@@ -1,43 +1,32 @@
 package tests_test
 
 import (
-
-	//commented by Xenia Lisovskaia
-	//quick workaround due syntax error (tests can't compilate, CI broken)
-
-	/*	"flag"
-		"fmt"
-		"strconv"
-		"time"
-		v13 "k8s.io/apimachinery/pkg/apis/meta/v1"
-		k8sv1 "k8s.io/api/core/v1"
-		ktests "kubevirt.io/kubevirt/tests"
-
-		"k8s.io/apimachinery/pkg/api/resource"
-		"kubevirt.io/kubevirt/pkg/kubecli"
-		"kubevirt.io/kubevirt/pkg/virtctl/expose"
-
-	*/
+	"flag"
 	"fmt"
-	expect "github.com/google/goexpect"
+	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"strconv"
+	"time"
+
+	expect "github.com/google/goexpect"
+	k8sv1 "k8s.io/api/core/v1"
+	v13 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "kubevirt.io/kubevirt/pkg/api/v1"
 	ktests "kubevirt.io/kubevirt/tests"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	"kubevirt.io/kubevirt/pkg/kubecli"
+	"kubevirt.io/kubevirt/pkg/virtctl/expose"
 )
 
-//commented by Xenia Lisovskaia
-//quick workaround due syntax error (tests can't compilate, CI broken)
-/*
 var _ = Describe("[rfe_id:1150][crit:high][vendor:cnv-qe@redhat.com][level:component]Network migration", func() {
-
-	 flag.Parse()
+	flag.Parse()
 
 	virtClient, err := kubecli.GetKubevirtClient()
 	ktests.PanicOnError(err)
 
 	var vmia *v1.VirtualMachineInstance
 	var vmib *v1.VirtualMachineInstance
-
 
 	ktests.BeforeAll(func() {
 		ktests.BeforeTestCleanup()
@@ -93,13 +82,20 @@ var _ = Describe("[rfe_id:1150][crit:high][vendor:cnv-qe@redhat.com][level:compo
 		Expect(string(vmi.Status.MigrationState.MigrationUID)).To(Equal(migrationUID))
 
 		By("Verifying the VMI's is in the running state")
-
-		Expect(vmi.Status.Phase).To(Equal(v1.Running)
-
-)}
+		Expect(vmi.Status.Phase).To(Equal(v1.Running))
+	}
 
 	Context("Masquerde VM is still avaible after migration", func() {
 		It("[test_id:CNV-2061] Masquerde VM is still availble after migration", func() {
+
+			curlReq := func(ip string, port string, vmi *v1.VirtualMachineInstance, resp string) {
+				ktests.WaitUntilVMIReady(vmi, ktests.LoggedInCirrosExpecter)
+				err := ktests.CheckForTextExpecter(vmi, []expect.Batcher{
+					&expect.BSnd{S: fmt.Sprintf("curl --silent --connect-timeout 5 --head %s%s  | grep 'HTTP/1.1 200 OK' | wc -l \n", ip, port)},
+					&expect.BExp{R: resp},
+				}, 60)
+				Expect(err).ToNot(HaveOccurred())
+			}
 
 			By("Create VMIs")
 			userData := "#!/bin/bash\npassword: fedora\nyum install -y nginx\nsystemctl enable nginx\nsystemctl start nginx\n"
@@ -135,7 +131,7 @@ var _ = Describe("[rfe_id:1150][crit:high][vendor:cnv-qe@redhat.com][level:compo
 			const serviceName = "cluster-ip-vmi"
 
 			virtctl := ktests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "virtualmachineinstance", "--namespace",
-					vmia.Namespace, vmia.Name, "--port", servicePort, "--name", serviceName, "--target-port", strconv.Itoa(testPort))
+				vmia.Namespace, vmia.Name, "--port", servicePort, "--name", serviceName, "--target-port", strconv.Itoa(testPort))
 			err := virtctl()
 			Expect(err).ToNot(HaveOccurred())
 
@@ -159,16 +155,4 @@ var _ = Describe("[rfe_id:1150][crit:high][vendor:cnv-qe@redhat.com][level:compo
 			curlReq(serviceIP, servicePort, vmib, resp)
 		})
 	})
-
 })
-
-
-*/
-func curlReq(ip string, port string, vmi *v1.VirtualMachineInstance, resp string) {
-	ktests.WaitUntilVMIReady(vmi, ktests.LoggedInCirrosExpecter)
-	err := ktests.CheckForTextExpecter(vmi, []expect.Batcher{
-		&expect.BSnd{S: fmt.Sprintf("curl --silent --connect-timeout 5 --head %s%s  | grep 'HTTP/1.1 200 OK' | wc -l \n", ip, port)},
-		&expect.BExp{R: resp},
-	}, 60)
-	Expect(err).ToNot(HaveOccurred())
-}

--- a/tests/networkpolicy_test.go
+++ b/tests/networkpolicy_test.go
@@ -1,10 +1,5 @@
 package tests_test
 
-//commented by Xenia Lisovskaia
-//quick workaround due syntax error (tests can't compilate, CI broken)
-
-/*
-
 import (
 	"flag"
 	"fmt"
@@ -48,6 +43,14 @@ var _ = Describe("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:compon
 	Context("Networkpolicy allow http port", func() {
 		It("[test_id:CNV-369] Set connectivity to only allow from http port", func() {
 
+			curlReq := func(ip string, port string, vmi *v1.VirtualMachineInstance, resp string) {
+				ktests.WaitUntilVMIReady(vmi, ktests.LoggedInCirrosExpecter)
+				err := ktests.CheckForTextExpecter(vmi, []expect.Batcher{
+					&expect.BSnd{S: fmt.Sprintf("curl --silent --connect-timeout 5 %s%s  | grep hellokubevirt | wc -l \n", ip, port)},
+					&expect.BExp{R: resp},
+				}, 60)
+				Expect(err).ToNot(HaveOccurred())
+			}
 			By("Create VMIs")
 			userData := "#cloud-config\npassword: fedora\nchpasswd: { expire: False }\n"
 			vmia = ktests.NewRandomVMIWithEphemeralDiskAndUserdata(ktests.ContainerDiskFor(ktests.ContainerDiskFedora), userData)
@@ -104,16 +107,3 @@ var _ = Describe("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		})
 	})
 })
-
-
-
-func curlReq(ip string, port string, vmi *v1.VirtualMachineInstance, resp string) {
-	ktests.WaitUntilVMIReady(vmi, ktests.LoggedInCirrosExpecter)
-	err := ktests.CheckForTextExpecter(vmi, []expect.Batcher{
-		&expect.BSnd{S: fmt.Sprintf("curl --silent --connect-timeout 5 %s%s  | grep hellokubevirt | wc -l \n", ip, port)},
-		&expect.BExp{R: resp},
-	}, 60)
-	Expect(err).ToNot(HaveOccurred())
-}
-
-*/


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Use anonymous function to fix curlReq redeclared issue

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
when running all the tests in the repo, separated functions for curlReq will cause below error:

tests/networkpolicy_test.go:103:75: curlReq redeclared in this block
  previous declaration at tests/network_migration_test.go:152:75

use anonymous function instead

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```
