### PR TITLE
Ignore failing on firewalld

### DIFF
--- a/roles/kubernetes-prerequisites/tasks/main.yml
+++ b/roles/kubernetes-prerequisites/tasks/main.yml
@@ -13,7 +13,7 @@
     state: stopped
     enabled: no
     name: firewalld
-  failed_when: "result|failed and not 'Could not find the requested service' in result.msg"
+  ignore_errors: yes
 
 - name: remove firewalld package
   package:


### PR DESCRIPTION
Earlier today, my scripts to deploy a kubernetes env via this repository started to fail with no other change in our code, complaining line was ansible about firewalld service (which was stopped and disabled)

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Do not fail on firewalld errors
```
